### PR TITLE
Replace animation variable strings with enum

### DIFF
--- a/Contents/mods/HorseMod/42/media/lua/client/HorseMod/Riding.lua
+++ b/Contents/mods/HorseMod/42/media/lua/client/HorseMod/Riding.lua
@@ -2,6 +2,7 @@
 local Mount = require("HorseMod/mount/Mount")
 local HorseUtils = require("HorseMod/Utils")
 local ModOptions = require("HorseMod/ModOptions")
+local AnimationVariables = require("HorseMod/AnimationVariables")
 
 ---@namespace HorseMod
 
@@ -126,10 +127,10 @@ HorseRiding.onKeyPressed = function(key)
         local mount = HorseRiding.getMount(player)
         if not mount then return end
 
-        if player:getVariableBoolean("RidingHorse") then
+        if player:getVariableBoolean(AnimationVariables.RIDING_HORSE) then
             local mountPair = mount.pair
-            local current = mountPair.mount:getVariableBoolean("HorseTrot")
-            mountPair:setAnimationVariable("HorseTrot", not current)
+            local current = mountPair.mount:getVariableBoolean(AnimationVariables.TROT)
+            mountPair:setAnimationVariable(AnimationVariables.TROT, not current)
         end
 
     ---JUMP
@@ -140,10 +141,10 @@ HorseRiding.onKeyPressed = function(key)
 
         local mountPair = mount.pair
         local horse = mountPair.mount
-        if player:getVariableBoolean("RidingHorse") 
-            and horse:getVariableBoolean("HorseGallop")
-            and not mountPair:getAnimationVariableBoolean("HorseJump") then
-            mountPair:setAnimationVariable("HorseJump", true)
+        if player:getVariableBoolean(AnimationVariables.RIDING_HORSE) 
+            and horse:getVariableBoolean(AnimationVariables.GALLOP)
+            and not mountPair:getAnimationVariableBoolean(AnimationVariables.JUMP) then
+            mountPair:setAnimationVariable(AnimationVariables.JUMP, true)
         end
     end
 end
@@ -164,7 +165,7 @@ HorseRiding.dismountOnHorseDeath = function(character)
                     rider:setBlockMovement(false)
                     rider:setIgnoreMovement(false)
                     rider:setIgnoreInputsForDirection(false)
-                    rider:setVariable("HorseDying", false)
+                    rider:setVariable(AnimationVariables.DYING, false)
                 end)
             return
         end
@@ -176,10 +177,10 @@ Events.OnCharacterDeath.Add(HorseRiding.dismountOnHorseDeath)
 
 ---@param player IsoPlayer
 local function initHorseMod(_, player)
-    player:setVariable("RidingHorse", false)
-    player:setVariable("MountingHorse", false)
-    player:setVariable("DismountFinished", false)
-    player:setVariable("MountFinished", false)
+    player:setVariable(AnimationVariables.RIDING_HORSE, false)
+    player:setVariable(AnimationVariables.MOUNTING_HORSE, false)
+    player:setVariable(AnimationVariables.DISMOUNT_FINISHED, false)
+    player:setVariable(AnimationVariables.MOUNT_FINISHED, false)
 end
 
 Events.OnCreatePlayer.Add(initHorseMod)

--- a/Contents/mods/HorseMod/42/media/lua/client/HorseMod/Sounds.lua
+++ b/Contents/mods/HorseMod/42/media/lua/client/HorseMod/Sounds.lua
@@ -1,6 +1,7 @@
 local HorseRiding = require("HorseMod/Riding")
 local HorseUtils = require("HorseMod/Utils")
 local Stamina = require("HorseMod/Stamina")
+local AnimationVariables = require("HorseMod/AnimationVariables")
 
 
 local HorseSounds = {}
@@ -258,16 +259,16 @@ local function shouldIdleSnort(h)
     if moving then
         return false
     end
-    if h:getVariableBoolean("MountingHorse") then
+    if h:getVariableBoolean(AnimationVariables.MOUNTING_HORSE) then
         return false
     end
-    if h:getVariableBoolean("RidingHorse") then
+    if h:getVariableBoolean(AnimationVariables.RIDING_HORSE) then
         return false
     end
-    if h:getVariableBoolean("HorseEating") then
+    if h:getVariableBoolean(AnimationVariables.EATING) then
         return false
     end
-    if h:getVariableBoolean("HorseHurt") then
+    if h:getVariableBoolean(AnimationVariables.HURT) then
         return false
     end
 
@@ -312,7 +313,7 @@ end
 ---@return boolean
 ---@nodiscard
 local function shouldPlayTiredGallop(horse)
-    if not (horse and horse.getVariableBoolean and horse:getVariableBoolean("HorseGallop")) then
+    if not (horse and horse.getVariableBoolean and horse:getVariableBoolean(AnimationVariables.GALLOP)) then
         return false
     end
     if not (Stamina and Stamina.get) then
@@ -411,19 +412,19 @@ function UpdateNearbyHorsesAudio()
             end
         else
             ensureEmitterBound(key, emitter)
-            checkParamAndTrigger(h, key, emitter, vol, "HorseDeath", "HorseDeath", function()
+            checkParamAndTrigger(h, key, emitter, vol, AnimationVariables.DEATH, "HorseDeath", function()
                 stopAllHorseSurfaces(emitter)
                 currentSound[key] = nil
                 currentSoundId[key] = nil
             end)
 
-            checkParamAndTrigger(h, key, emitter, vol, "HorseHurt", "HorsePain")
+            checkParamAndTrigger(h, key, emitter, vol, AnimationVariables.HURT, "HorsePain")
 
-            checkParamAndTrigger(h, key, emitter, vol, "HorseEating", "HorseEatingGrass")
+            checkParamAndTrigger(h, key, emitter, vol, AnimationVariables.EATING, "HorseEatingGrass")
 
             local moving = h:isAnimalMoving() or h:getVariableBoolean("bMoving")
             local running = h.getVariableBoolean and h:getVariableBoolean("animalRunning")
-            local base = running and "HorseGallop" or "HorseWalk"
+            local base = running and AnimationVariables.GALLOP or AnimationVariables.WALK
             local speed = running and "Gallop" or "Walk"
             local rough = isSquareRough(h:getSquare())
             local suffix = rough and "Dirt" or "Concrete"
@@ -499,12 +500,12 @@ function UpdateHorseAudio(player, square)
 
     local speed
     local base
-    if horse:getVariableBoolean("HorseGallop") then
-        speed, base = "Gallop", "HorseGallop"
-    elseif horse:getVariableBoolean("HorseTrot") then
-        speed, base = "Trot", "HorseTrot"
+    if horse:getVariableBoolean(AnimationVariables.GALLOP) then
+        speed, base = "Gallop", AnimationVariables.GALLOP
+    elseif horse:getVariableBoolean(AnimationVariables.TROT) then
+        speed, base = "Trot", AnimationVariables.TROT
     else
-        speed, base = "Walk", "HorseWalk"
+        speed, base = "Walk", AnimationVariables.WALK
     end
 
     local sq = square or horse:getSquare()
@@ -514,19 +515,19 @@ function UpdateHorseAudio(player, square)
 
     local moving = horse:isAnimalMoving()
         or horse:getVariableBoolean("animalWalking")
-        or horse:getVariableBoolean("HorseGallop")
+        or horse:getVariableBoolean(AnimationVariables.GALLOP)
 
     local key = horseKey(horse)
     local dt = GameTime.getInstance():getTimeDelta()
     local rt = realTime()
 
-    checkParamAndTrigger(horse, key, emitter, vol, "HorseDeath", "HorseDeath", function()
+    checkParamAndTrigger(horse, key, emitter, vol, AnimationVariables.DEATH, "HorseDeath", function()
         stopAllHorseSurfaces(emitter)
         currentSound[key] = nil
         secAccum[key] = 0
     end)
-    checkParamAndTrigger(horse, key, emitter, vol, "HorseHurt", "HorsePain")
-    checkParamAndTrigger(horse, key, emitter, vol, "HorseEating", "HorseEatingGrass")
+    checkParamAndTrigger(horse, key, emitter, vol, AnimationVariables.HURT, "HorsePain")
+    checkParamAndTrigger(horse, key, emitter, vol, AnimationVariables.EATING, "HorseEatingGrass")
 
     maybePlayStressed(horse, key, emitter, rt, vol)
     maybePlayIdleSnort(horse, key, emitter, rt, vol)

--- a/Contents/mods/HorseMod/42/media/lua/client/HorseMod/horse/Hooks.lua
+++ b/Contents/mods/HorseMod/42/media/lua/client/HorseMod/horse/Hooks.lua
@@ -1,4 +1,5 @@
 local HorseUtils = require("HorseMod/Utils")
+local AnimationVariables = require("HorseMod/AnimationVariables")
 
 -- Hook ISAnimalUI to setup our animation when it's a horse
 
@@ -8,9 +9,9 @@ local function setHorseAvatarVariables(avatar)
     if not avatar or not avatar.setVariable or not avatar.animal then return end
     if not HorseUtils.isHorse(avatar.animal) then return end
     local walk, gallop = GetSpeeds()
-    avatar:setVariable("isHorse", true)
-    avatar:setVariable("HorseWalkSpeed", walk)
-    avatar:setVariable("HorseRunSpeed", gallop)
+    avatar:setVariable(AnimationVariables.IS_HORSE, true)
+    avatar:setVariable(AnimationVariables.WALK_SPEED, walk)
+    avatar:setVariable(AnimationVariables.RUN_SPEED, gallop)
 end
 
 ---@diagnostic disable-next-line: duplicate-set-field
@@ -18,9 +19,9 @@ ISAnimalUI.create = function(self)
     old_create(self)
     local walk, gallop = GetSpeeds()
     if HorseUtils.isHorse(self.animal) then
-        self.avatarPanel:setVariable("isHorse", true)
-        self.avatarPanel:setVariable("HorseWalkSpeed", walk)
-        self.avatarPanel:setVariable("HorseRunSpeed", gallop)
+        self.avatarPanel:setVariable(AnimationVariables.IS_HORSE, true)
+        self.avatarPanel:setVariable(AnimationVariables.WALK_SPEED, walk)
+        self.avatarPanel:setVariable(AnimationVariables.RUN_SPEED, gallop)
     end
 end
 

--- a/Contents/mods/HorseMod/42/media/lua/client/HorseMod/horse/HorseInteractions.lua
+++ b/Contents/mods/HorseMod/42/media/lua/client/HorseMod/horse/HorseInteractions.lua
@@ -1,6 +1,7 @@
 local HorseUtils  = require("HorseMod/Utils")
 local HorseRiding = require("HorseMod/Riding")
 local Mounting = require("HorseMod/Mounting")
+local AnimationVariables = require("HorseMod/AnimationVariables")
 -- local HorseAttachments = require("HorseMod/HorseAttachments")
 
 ---@param context ISContextMenu
@@ -81,11 +82,11 @@ local function handleJoypadMountButton(player)
     if joypadHasUIFocus(pid) then return end
     if player:hasTimedActions() then return end
     if player:getVehicle() then return end
-    if player:getVariableBoolean("MountingHorse") then return end
+    if player:getVariableBoolean(AnimationVariables.MOUNTING_HORSE) then return end
 
     local mountedHorse = HorseRiding.getMountedHorse(player)
     if mountedHorse then
-        if player:getVariableBoolean("RidingHorse") then
+        if player:getVariableBoolean(AnimationVariables.RIDING_HORSE) then
             Mounting.dismountHorse(player)
         end
         return

--- a/Contents/mods/HorseMod/42/media/lua/client/HorseMod/mount/Mount.lua
+++ b/Contents/mods/HorseMod/42/media/lua/client/HorseMod/mount/Mount.lua
@@ -1,6 +1,7 @@
 local MountController = require("HorseMod/mount/MountController")
 local HorseDamage = require("HorseMod/horse/HorseDamage")
 local HorseUtils = require("HorseMod/Utils")
+local AnimationVariables = require("HorseMod/AnimationVariables")
 
 
 local JOY_DEADZONE        = 0.30   -- ignore tiny stick drift
@@ -113,7 +114,7 @@ function Mount:getCurrentInput()
         },
         run = run,
         -- FIXME: Change this when fixing the mod option keybinds
-        trot = self.pair.mount:getVariableBoolean("HorseTrot"),
+        trot = self.pair.mount:getVariableBoolean(AnimationVariables.TROT),
     }
 end
 
@@ -121,11 +122,11 @@ end
 ---@return boolean
 ---@nodiscard
 function Mount:dying()
-    if self.pair.mount:getVariableBoolean("HorseDying") then
+    if self.pair.mount:getVariableBoolean(AnimationVariables.DYING) then
         self.pair.rider:setIgnoreMovement(true)
         self.pair.rider:setBlockMovement(true)
         self.pair.rider:setIgnoreInputsForDirection(true)
-        self.pair.rider:setVariable("HorseDying", true)
+        self.pair.rider:setVariable(AnimationVariables.DYING, true)
         HorseUtils.runAfter(0.5, function()
             HorseDamage.knockDownNearbyZombies(self.pair.mount)
         end)
@@ -146,8 +147,8 @@ end
 
 
 function Mount:cleanup()
-    self.pair:setAnimationVariable("RidingHorse", false)
-    self.pair:setAnimationVariable("HorseTrot", false)
+    self.pair:setAnimationVariable(AnimationVariables.RIDING_HORSE, false)
+    self.pair:setAnimationVariable(AnimationVariables.TROT, false)
 
     local attached = self.pair.rider:getAttachedAnimals()
     attached:remove(self.pair.mount)
@@ -156,8 +157,8 @@ function Mount:cleanup()
     self.pair.mount:getBehavior():setBlockMovement(false)
     self.pair.mount:getPathFindBehavior2():reset()
 
-    self.pair.rider:setVariable("HorseTrot", false)
-    self.pair.rider:setVariable("DismountStarted", false)
+    self.pair.rider:setVariable(AnimationVariables.TROT, false)
+    self.pair.rider:setVariable(AnimationVariables.DISMOUNT_STARTED, false)
     self.pair.rider:setAllowRun(true)
     self.pair.rider:setAllowSprint(true)
     self.pair.rider:setTurnDelta(1)
@@ -168,7 +169,7 @@ function Mount:cleanup()
     self.pair.mount:setVariable("animalWalking", false)
     self.pair.mount:setVariable("animalRunning", false)
 
-    self.pair.rider:setVariable("MountingHorse", false)
+    self.pair.rider:setVariable(AnimationVariables.MOUNTING_HORSE, false)
     self.pair.rider:setVariable("isTurningLeft", false)
     self.pair.rider:setVariable("isTurningRight", false)
 end
@@ -181,8 +182,8 @@ function Mount.new(pair)
     pair.rider:getAttachedAnimals():add(pair.mount)
     pair.mount:getData():setAttachedPlayer(pair.rider)
 
-    pair:setAnimationVariable("RidingHorse", true)
-    pair:setAnimationVariable("HorseTrot", false)
+    pair:setAnimationVariable(AnimationVariables.RIDING_HORSE, true)
+    pair:setAnimationVariable(AnimationVariables.TROT, false)
     pair.rider:setAllowRun(false)
     pair.rider:setAllowSprint(false)
 
@@ -192,7 +193,7 @@ function Mount.new(pair)
     pair.rider:setVariable("isTurningRight", false)
 
     local geneSpeed = pair.mount:getUsedGene("speed"):getCurrentValue()
-    pair.rider:setVariable("geneSpeed", geneSpeed)
+    pair.rider:setVariable(AnimationVariables.GENE_SPEED, geneSpeed)
 
     pair.mount:getPathFindBehavior2():reset()
     pair.mount:getBehavior():setBlockMovement(true)
@@ -204,7 +205,7 @@ function Mount.new(pair)
 
     -- TODO: are these even needed
     pair.mount:setWild(false)
-    pair.mount:setVariable("isHorse", true)
+    pair.mount:setVariable(AnimationVariables.IS_HORSE, true)
 
     local o = setmetatable(
         {

--- a/Contents/mods/HorseMod/42/media/lua/client/HorseMod/mount/MountController.lua
+++ b/Contents/mods/HorseMod/42/media/lua/client/HorseMod/mount/MountController.lua
@@ -2,6 +2,7 @@ local Stamina = require("HorseMod/Stamina")
 local HorseUtils = require("HorseMod/Utils")
 local AttachmentData = require("HorseMod/attachments/AttachmentData")
 local Attachments = require("HorseMod/attachments/Attachments")
+local AnimationVariables = require("HorseMod/AnimationVariables")
 
 
 ---@param state "walk"|"gallop"
@@ -158,7 +159,7 @@ local function blockedBetween(fromSq, toSq, horse)
     -- FENCE
     local hop = edgeHoppableBetween(fromSq, toSq)
     if hop and hop:isHoppable() then
-        if horse and horse:getVariableBoolean("HorseJump") then
+        if horse and horse:getVariableBoolean(AnimationVariables.JUMP) then
             return false
         else
             return true
@@ -663,9 +664,9 @@ function MountController:updateSpeed(input, deltaTime)
     local geneSpeed = getGeneticSpeed(self.mount.pair.mount) * self:getVegetationEffect(input, deltaTime)
 
     -- TODO: is this check really necessary? does changing the value cause more overhead than reading it?
-    local currentGeneSpeed = self.mount.pair.mount:getVariableFloat("geneSpeed", 0)
+    local currentGeneSpeed = self.mount.pair.mount:getVariableFloat(AnimationVariables.GENE_SPEED, 0)
     if currentGeneSpeed ~= geneSpeed then
-        self.mount.pair:setAnimationVariable("geneSpeed", geneSpeed)
+        self.mount.pair:setAnimationVariable(AnimationVariables.GENE_SPEED, geneSpeed)
     end
 
     if input.run then
@@ -677,13 +678,13 @@ function MountController:updateSpeed(input, deltaTime)
         end
     end
 
-    self.mount.pair.mount:setVariable("HorseWalkSpeed", walkMultiplier)
-    self.mount.pair.mount:setVariable("HorseTrotSpeed",  walkMultiplier * TROT_MULT)
-    self.mount.pair.mount:setVariable("HorseRunSpeed", gallopRawSpeed)
+    self.mount.pair.mount:setVariable(AnimationVariables.WALK_SPEED, walkMultiplier)
+    self.mount.pair.mount:setVariable(AnimationVariables.TROT_SPEED,  walkMultiplier * TROT_MULT)
+    self.mount.pair.mount:setVariable(AnimationVariables.RUN_SPEED, gallopRawSpeed)
 
-    self.mount.pair.rider:setVariable("HorseWalkSpeed", walkMultiplier * PLAYER_SYNC_TUNER)
-    self.mount.pair.rider:setVariable("HorseTrotSpeed",  walkMultiplier * TROT_MULT * PLAYER_SYNC_TUNER)
-    self.mount.pair.rider:setVariable("HorseRunSpeed", gallopRawSpeed * PLAYER_SYNC_TUNER)
+    self.mount.pair.rider:setVariable(AnimationVariables.WALK_SPEED, walkMultiplier * PLAYER_SYNC_TUNER)
+    self.mount.pair.rider:setVariable(AnimationVariables.TROT_SPEED,  walkMultiplier * TROT_MULT * PLAYER_SYNC_TUNER)
+    self.mount.pair.rider:setVariable(AnimationVariables.RUN_SPEED, gallopRawSpeed * PLAYER_SYNC_TUNER)
 
     -- speed/locomotion
     local moving = (input.movement.x ~= 0 or input.movement.y ~= 0)
@@ -706,7 +707,7 @@ function MountController:updateStamina(input, deltaTime)
     if input.movement.x ~= 0 or input.movement.y ~= 0 then
         if input.run then
             staminaChange = -Stamina.DRAIN_RUN
-        elseif self.mount.pair.mount:getVariableBoolean("HorseTrot") == true then
+        elseif self.mount.pair.mount:getVariableBoolean(AnimationVariables.TROT) == true then
             staminaChange = Stamina.REGEN_TROT
         else
             staminaChange = Stamina.REGEN_WALK
@@ -765,16 +766,16 @@ function MountController:updateReins(input)
         self:setReinsState(mount, reinsItem, movementState)
 
         ---@TODO these states should be defined when the rider mounts the horse
-        mountPair.rider:setVariable("HasReins", true)
+        mountPair.rider:setVariable(AnimationVariables.HAS_REINS, true)
     else
-        mountPair.rider:setVariable("HasReins", false)
+        mountPair.rider:setVariable(AnimationVariables.HAS_REINS, false)
     end
 end
 
 
 ---@param input MountController.Input
 function MountController:update(input)
-    assert(self.mount.pair.rider:getVariableString("RidingHorse") == "true")
+    assert(self.mount.pair.rider:getVariableString(AnimationVariables.RIDING_HORSE) == "true")
 
     self.mount.pair.rider:setSneaking(true)
     self.mount.pair.rider:setIgnoreAutoVault(true)
@@ -805,10 +806,10 @@ function MountController:update(input)
 
         self.mount.pair.mount:setVariable("bPathfind", true)
         self.mount.pair.mount:setVariable("animalWalking", not input.run)
-        self.mount.pair:setAnimationVariable("HorseGallop", input.run)
+        self.mount.pair:setAnimationVariable(AnimationVariables.GALLOP, input.run)
     else
         self.mount.pair.mount:setVariable("bPathfind", false)
-        self.mount.pair:setAnimationVariable("HorseGallop", false)
+        self.mount.pair:setAnimationVariable(AnimationVariables.GALLOP, false)
         self.mount.pair.mount:setVariable("animalWalking", false)
     end
 
@@ -833,7 +834,6 @@ function MountController:update(input)
     self.mount.pair.rider:setX(self.mount.pair.mount:getX())
     self.mount.pair.rider:setY(self.mount.pair.mount:getY())
     self.mount.pair.rider:setZ(self.mount.pair.mount:getZ())
-    self.mount.pair.rider:setVariable("mounted", true)
     UpdateHorseAudio(self.mount.pair.rider)
 end
 

--- a/Contents/mods/HorseMod/42/media/lua/client/HorseMod/player/MountedAttack.lua
+++ b/Contents/mods/HorseMod/42/media/lua/client/HorseMod/player/MountedAttack.lua
@@ -1,4 +1,5 @@
 local HorseRiding = require("HorseMod/Riding")
+local AnimationVariables = require("HorseMod/AnimationVariables")
 
 ---@class MountedAttack
 ---@field active boolean
@@ -16,7 +17,7 @@ MountedAttack.KICK_LOCK_SECONDS = 1.4
 local function updateBannedAttacking(player)
     if not player then return end
 
-    if player:getVariableBoolean("RidingHorse") then
+    if player:getVariableBoolean(AnimationVariables.RIDING_HORSE) then
         player:setBannedAttacking(true)
     else
         player:setBannedAttacking(false)
@@ -34,9 +35,9 @@ local function updateKickCooldown(player)
     local ks = MountedAttack[id]
     if not ks or not ks.active then return end
 
-    if not player:getVariableBoolean("RidingHorse") then
-        player:setVariable("kickLeft", false)
-        player:setVariable("kickRight", false)
+    if not player:getVariableBoolean(AnimationVariables.RIDING_HORSE) then
+        player:setVariable(AnimationVariables.KICK_LEFT, false)
+        player:setVariable(AnimationVariables.KICK_RIGHT, false)
         MountedAttack[id] = nil
         return
     end
@@ -44,15 +45,15 @@ local function updateKickCooldown(player)
     ks.timeLeft = ks.timeLeft - GameTime.getInstance():getTimeDelta()
     if ks.timeLeft <= 0 then
         if ks.left then
-            player:setVariable("kickLeft", false)
+            player:setVariable(AnimationVariables.KICK_LEFT, false)
         end
 
         if ks.right then
-            player:setVariable("kickRight", false)
+            player:setVariable(AnimationVariables.KICK_RIGHT, false)
         end
 
-        player:setVariable("idleKicking", false)
-        player:setVariable("moveKicking", false)
+        player:setVariable(AnimationVariables.IDLE_KICKING, false)
+        player:setVariable(AnimationVariables.MOVE_KICKING, false)
         MountedAttack[id] = nil
     end
 end
@@ -65,7 +66,7 @@ function MountedAttack.horseKick(key)
     if key ~= Keyboard.KEY_SPACE then return end
 
     local player = getSpecificPlayer(0)
-    if not player or not player:getVariableBoolean("RidingHorse") then return end
+    if not player or not player:getVariableBoolean(AnimationVariables.RIDING_HORSE) then return end
 
     local id = player:getPlayerNum()
     local ks = MountedAttack[id]
@@ -104,8 +105,8 @@ function MountedAttack.horseKick(key)
     local rightDistSq = rdx * rdx + rdy * rdy
 
     local kickLeft = (leftDistSq < rightDistSq)
-    player:setVariable("kickLeft", kickLeft)
-    player:setVariable("kickRight", not kickLeft)
+    player:setVariable(AnimationVariables.KICK_LEFT, kickLeft)
+    player:setVariable(AnimationVariables.KICK_RIGHT, not kickLeft)
 
     MountedAttack[id] = {
         active = true,

--- a/Contents/mods/HorseMod/42/media/lua/client/HorseMod/player/PlayerDamage.lua
+++ b/Contents/mods/HorseMod/42/media/lua/client/HorseMod/player/PlayerDamage.lua
@@ -1,6 +1,7 @@
 local HorseRiding = require("HorseMod/Riding")
 local HorseUtils = require("HorseMod/Utils")
 local HorseDamage = require("HorseMod/horse/HorseDamage")
+local AnimationVariables = require("HorseMod/AnimationVariables")
 
 local PlayerDamage = {}
 
@@ -348,7 +349,7 @@ function PlayerDamage.onZombieAttack_checkAndRedirect(zombie)
     if not player then
         return
     end
-    if not player:getVariableBoolean("RidingHorse") then
+    if not player:getVariableBoolean(AnimationVariables.RIDING_HORSE) then
         return
     end
     local target = zombie:getTarget()

--- a/Contents/mods/HorseMod/42/media/lua/shared/HorseMod/AnimationVariables.lua
+++ b/Contents/mods/HorseMod/42/media/lua/shared/HorseMod/AnimationVariables.lua
@@ -1,0 +1,45 @@
+---@namespace HorseMod
+
+---@enum AnimationVariables
+return {
+    --- Must always be true on all horses for their animations to play properly.
+    IS_HORSE = "isHorse",
+    WALK = "HorseWalk",
+    GALLOP = "HorseGallop",
+    TROT = "HorseTrot",
+    JUMP = "HorseJump",
+    DYING = "HorseDying",
+
+    -- Activates mounted player animations while true
+    RIDING_HORSE = "RidingHorse",
+    MOUNTING_HORSE = "MountingHorse",
+    MOUNT_FINISHED = "MountFinished",
+    DISMOUNT_STARTED = "DismountStarted",
+    DISMOUNT_FINISHED = "DismountFinished",
+
+    HAS_REINS = "HasReins",
+
+    EATING = "HorseEating",
+    EATING_HAND = "HorseEatingHand",
+    HURT = "HorseHurt",
+    DEATH = "HorseDeath",
+    
+    EQUIP_FINISHED = "EquipFinished",
+
+    KICK_LEFT = "kickLeft",
+    KICK_RIGHT = "kickRight",
+    IDLE_KICKING = "idleKicking",
+    MOVE_KICKING = "moveKicking",
+
+    WALK_SPEED = "HorseWalkSpeed",
+    TROT_SPEED = "HorseTrotSpeed",
+    RUN_SPEED = "HorseRunSpeed",
+    -- Multiplier to the horse's speed from genetics
+    GENE_SPEED = "geneSpeed",
+    -- unused
+    GENE_STRENGTH = "geneStrength",
+    -- unused
+    GENE_STAMINA = "geneStamina",
+    -- unused
+    GENE_CARRYWEIGHT = "geneCarryWeight"
+}

--- a/Contents/mods/HorseMod/42/media/lua/shared/HorseMod/HorseManager.lua
+++ b/Contents/mods/HorseMod/42/media/lua/shared/HorseMod/HorseManager.lua
@@ -1,5 +1,6 @@
 local HorseUtils = require("HorseMod/Utils")
 local Event = require("HorseMod/Event")
+local AnimationVariables = require("HorseMod/AnimationVariables")
 
 ---@namespace HorseMod
 
@@ -49,16 +50,16 @@ end
 
 ---@param horse IsoAnimal
 local function initialiseHorse(horse)
-    horse:setVariable("isHorse", true)
+    horse:setVariable(AnimationVariables.IS_HORSE, true)
 
     local speed = horse:getUsedGene("speed"):getCurrentValue()
-    horse:setVariable("geneSpeed", speed)
+    horse:setVariable(AnimationVariables.GENE_SPEED, speed)
     local strength = horse:getUsedGene("strength"):getCurrentValue()
-    horse:setVariable("geneStrength", strength)
+    horse:setVariable(AnimationVariables.GENE_STRENGTH, strength)
     local stamina = horse:getUsedGene("stamina"):getCurrentValue()
-    horse:setVariable("geneStamina", stamina)
+    horse:setVariable(AnimationVariables.GENE_STAMINA, stamina)
     local carry = horse:getUsedGene("carryWeight"):getCurrentValue()
-    horse:setVariable("geneCarryWeight", carry)
+    horse:setVariable(AnimationVariables.GENE_CARRYWEIGHT, carry)
 end
 
 ---Utility function to find a horse by its animal ID.

--- a/Contents/mods/HorseMod/42/media/lua/shared/HorseMod/Stamina.lua
+++ b/Contents/mods/HorseMod/42/media/lua/shared/HorseMod/Stamina.lua
@@ -1,4 +1,5 @@
 local HorseManager = require("HorseMod/HorseManager")
+local AnimationVariables = require("HorseMod/AnimationVariables")
 
 
 ---@namespace HorseMod
@@ -89,7 +90,7 @@ function Stamina.shouldRun(horse, input, moving)
     local minRunStamina = Stamina.MAX * Stamina.MIN_RUN_PERCENT
     local wantsRun = input.run and true or false
     local runAllowed = false
-    local isGalloping = horse:getVariableBoolean("HorseGallop")
+    local isGalloping = horse:getVariableBoolean(AnimationVariables.GALLOP)
     local needsStaminaRecovery = false
 
     if isGalloping then

--- a/Contents/mods/HorseMod/42/media/lua/shared/HorseMod/TimedActions/DismountHorseAction.lua
+++ b/Contents/mods/HorseMod/42/media/lua/shared/HorseMod/TimedActions/DismountHorseAction.lua
@@ -1,5 +1,7 @@
 require("TimedActions/ISBaseTimedAction")
 
+local AnimationVariables = require("HorseMod/AnimationVariables")
+
 
 ---@namespace HorseMod
 
@@ -39,8 +41,8 @@ function DismountHorseAction:update()
     -- keep the horse locked facing the stored direction
     self.horse:setDir(self._lockDir)
 
-    if self.character:getVariableBoolean("DismountFinished") == true then
-        self.character:setVariable("DismountFinished", false)
+    if self.character:getVariableBoolean(AnimationVariables.DISMOUNT_FINISHED) == true then
+        self.character:setVariable(AnimationVariables.DISMOUNT_FINISHED, false)
         self:forceComplete()
     end
 end
@@ -52,7 +54,7 @@ function DismountHorseAction:start()
     self.horse:stopAllMovementNow()
 
     self._lockDir  = self.horse:getDir()
-    self.character:setVariable("DismountStarted", true)
+    self.character:setVariable(AnimationVariables.DISMOUNT_STARTED, true)
 
     if self.side == "right" then
         if self.hasSaddle then
@@ -72,7 +74,7 @@ end
 
 function DismountHorseAction:stop()
     self.horse:getBehavior():setBlockMovement(false)
-    self.character:setVariable("DismountStarted", false)
+    self.character:setVariable(AnimationVariables.DISMOUNT_STARTED, false)
     ISBaseTimedAction.stop(self)
 end
 

--- a/Contents/mods/HorseMod/42/media/lua/shared/HorseMod/TimedActions/ISFeedFromHand.lua
+++ b/Contents/mods/HorseMod/42/media/lua/shared/HorseMod/TimedActions/ISFeedFromHand.lua
@@ -1,11 +1,12 @@
 local HorseUtils = require("HorseMod/Utils")
+local AnimationVariables = require("HorseMod/AnimationVariables")
 
 local _originalFeedFromHandStart = ISFeedAnimalFromHand.start
 
 function ISFeedAnimalFromHand:start()
     if HorseUtils.isHorse(self.animal) then
         self:setActionAnim("Bob_Horse_EatHand")
-        self.animal:setVariable("HorseEatingHand", true)
+        self.animal:setVariable(AnimationVariables.EATING_HAND, true)
     end
     _originalFeedFromHandStart(self)
 end
@@ -24,7 +25,7 @@ local _originalFeedFromHandStop = ISFeedAnimalFromHand.stop
 
 function ISFeedAnimalFromHand:stop()
     if HorseUtils.isHorse(self.animal) then
-        self.animal:setVariable("HorseEatingHand", false)
+        self.animal:setVariable(AnimationVariables.EATING_HAND, false)
     end
     _originalFeedFromHandStop(self)
 end
@@ -33,7 +34,7 @@ local _originalFeedFromHandPerform = ISFeedAnimalFromHand.perform
 
 function ISFeedAnimalFromHand:perform()
     if HorseUtils.isHorse(self.animal) then
-        self.animal:setVariable("HorseEatingHand", false)
+        self.animal:setVariable(AnimationVariables.EATING_HAND, false)
     end
     _originalFeedFromHandPerform(self)
 end
@@ -42,7 +43,7 @@ local _originalFeedFromHandForceStop = ISFeedAnimalFromHand.forceStop
 
 function ISFeedAnimalFromHand:forceStop()
     if HorseUtils.isHorse(self.animal) then
-        self.animal:setVariable("HorseEatingHand", false)
+        self.animal:setVariable(AnimationVariables.EATING_HAND, false)
     end
     _originalFeedFromHandForceStop(self)
 end

--- a/Contents/mods/HorseMod/42/media/lua/shared/HorseMod/TimedActions/ISHorseEquipGear.lua
+++ b/Contents/mods/HorseMod/42/media/lua/shared/HorseMod/TimedActions/ISHorseEquipGear.lua
@@ -3,6 +3,7 @@
 ---REQUIREMENTS
 local Attachments = require("HorseMod/attachments/Attachments")
 local ContainerManager = require("HorseMod/attachments/ContainerManager")
+local AnimationVariables = require("HorseMod/AnimationVariables")
 
 ---@class ISHorseEquipGear : ISBaseTimedAction, umbrella.NetworkedTimedAction
 ---@field horse IsoAnimal
@@ -24,7 +25,7 @@ function ISHorseEquipGear:start()
     local equipBehavior = self.equipBehavior
     
     -- set the action animation
-    self.character:setVariable("EquipFinished", false)
+    self.character:setVariable(AnimationVariables.EQUIP_FINISHED, false)
 
     local anim = equipBehavior.anim
     local animationVar = anim and anim[self.side] or "Loot"
@@ -44,7 +45,7 @@ function ISHorseEquipGear:update()
 
     -- end when
     local maxTime = self.maxTime
-    if maxTime == -1 and self.character:getVariableBoolean("EquipFinished") then
+    if maxTime == -1 and self.character:getVariableBoolean(AnimationVariables.EQUIP_FINISHED) then
         self:forceComplete()
     end
 end

--- a/Contents/mods/HorseMod/42/media/lua/shared/HorseMod/TimedActions/MountHorseAction.lua
+++ b/Contents/mods/HorseMod/42/media/lua/shared/HorseMod/TimedActions/MountHorseAction.lua
@@ -1,6 +1,7 @@
 require("TimedActions/ISBaseTimedAction")
 
 local MountPair = require("HorseMod/MountPair")
+local AnimationVariables = require("HorseMod/AnimationVariables")
 
 
 ---@namespace HorseMod
@@ -38,8 +39,8 @@ function MountHorseAction:update()
     self.horse:setDir(self.lockDir)
     self.character:setDir(self.lockDir)
 
-    if self.character:getVariableBoolean("MountFinished") == true then
-        self.character:setVariable("MountFinished", false)
+    if self.character:getVariableBoolean(AnimationVariables.MOUNT_FINISHED) == true then
+        self.character:setVariable(AnimationVariables.MOUNT_FINISHED, false)
         self:forceComplete()
     end
 end
@@ -51,14 +52,14 @@ function MountHorseAction:start()
     self.horse:getBehavior():setBlockMovement(true)
     self.horse:stopAllMovementNow()
 
-    self.horse:setVariable("HorseDying", false)
+    self.horse:setVariable(AnimationVariables.DYING, false)
 
     self.lockDir = self.horse:getDir()
     self.character:setDir(self.lockDir)
 
-    self.character:setVariable("MountingHorse", true)
-    self.character:setVariable("MountFinished", false)
-    self.character:setVariable("HorseDying", false)
+    self.character:setVariable(AnimationVariables.MOUNTING_HORSE, true)
+    self.character:setVariable(AnimationVariables.MOUNT_FINISHED, false)
+    self.character:setVariable(AnimationVariables.DYING, false)
 
     if self.side == "right" then
         if self.saddle then
@@ -81,13 +82,13 @@ end
 function MountHorseAction:stop()
     self.horse:getBehavior():setBlockMovement(false)
 
-    self.pair:setAnimationVariable("RidingHorse", false)
-    self.character:setVariable("MountingHorse", false)
+    self.pair:setAnimationVariable(AnimationVariables.RIDING_HORSE, false)
+    self.character:setVariable(AnimationVariables.MOUNTING_HORSE, false)
     self.character:setVariable("isTurningLeft", false)
     self.character:setVariable("isTurningRight", false)
     self.character:setTurnDelta(1)
 
-    self.character:setVariable("MountingHorse", false)
+    self.character:setVariable(AnimationVariables.MOUNTING_HORSE, false)
 
     ISBaseTimedAction.stop(self)
 end


### PR DESCRIPTION
Replaces all Lua references to our custom animation variables with an enum. This enum could be a good place to document them, however I did not do this for the majority because I'm still not 100% sure what they do.

To keep things simple I did not create an enum for the vanilla animation variables we are also using, however this may be worth considering as well.

There are intentionally no changes to actual functionality or any cleanup, even in places where it is obviously needed (some functions set the same variable twice in a row). As the only exception to this I removed a single reference to a `mounted` variable which was not referenced anywhere else in Lua or XML.

Contributes to #20.

Not merging right away because I didn't test this, going to bed now.