### PR TITLE
Fix #67

### DIFF
--- a/Contents/mods/HorseMod/42/media/lua/shared/HorseMod/EventHandler.lua
+++ b/Contents/mods/HorseMod/42/media/lua/shared/HorseMod/EventHandler.lua
@@ -1,0 +1,14 @@
+---@namespace HorseMod
+
+---REQUIREMENTS
+local Event = require("HorseMod/Event")
+
+local EventHandler = {}
+
+---Triggers when a horse gets loaded in.
+EventHandler.onHorseAdded = Event.new() ---@as Event<IsoAnimal>
+
+---Triggers when a horse gets unloaded.
+EventHandler.onHorseRemoved = Event.new() ---@as Event<IsoAnimal>
+
+return EventHandler

--- a/Contents/mods/HorseMod/42/media/lua/shared/HorseMod/HorseDefinitions.lua
+++ b/Contents/mods/HorseMod/42/media/lua/shared/HorseMod/HorseDefinitions.lua
@@ -9,9 +9,9 @@ local HorseDefinitions = {
         AP = "american_paint", -- American Paint
         GDA = "appaloosa", -- Appaloosa
         T = "thoroughbred", -- Thoroughbred
-        AQHBR = "american_quarter_blue_roan", -- American Quarter Horse Blue Roan
-        LPA = "leopard_appaloosa", -- Leopard Appaloosa
-        APHO = "american_paint_horse_overo", -- American Paint Horse Overo
+        AQHBR = "blue_roan", -- American Quarter Horse Blue Roan
+        LPA = "spotted_appaloosa", -- Leopard Appaloosa
+        APHO = "american_paint_overo", -- American Paint Horse Overo
         FBG = "flea_bitten_grey", -- Flea Bitten Grey
     },
     PATHS = {

--- a/Contents/mods/HorseMod/42/media/lua/shared/HorseMod/HorseModData.lua
+++ b/Contents/mods/HorseMod/42/media/lua/shared/HorseMod/HorseModData.lua
@@ -1,5 +1,5 @@
 ---REQUIREMENTS
-local HorseManager = require("HorseMod/HorseManager")
+local EventHandler = require("HorseMod/EventHandler")
 
 ---@namespace HorseMod
 
@@ -39,9 +39,7 @@ end
 ---Initialises all mod data kinds for the given horse.
 ---@param horse IsoAnimal
 function HorseModData.initialize(horse)
-    local modData = horse:getModData()
-    modData.horseModData = modData.horseModData or {}
-    local horseModData = modData.horseModData
+    local horseModData = HorseModData.getAll(horse)
     for name, kind in pairs(HorseModData.modDataKinds) do
         horseModData[name] = horseModData[name] or {}
         local kindModData = horseModData[name] --[[@as table goes crazy without it]]
@@ -51,22 +49,46 @@ function HorseModData.initialize(horse)
     end
 end
 
+EventHandler.onHorseAdded:add(HorseModData.initialize)
+
+
 ---Returns mod data of a specific kind.
 ---@generic T
 ---@param horse IsoAnimal
 ---@param kind ModDataKind<T>
 ---@return T modData
 function HorseModData.get(horse, kind)
-    local modData = horse:getModData()
-
     -- get the kind mod data
-    local horseModData = modData.horseModData --[[@as table<string, T>]]
+    local horseModData = HorseModData.getAll(horse)
     local kindModData = horseModData[kind.name]
     
     return kindModData
 end
 
-HorseManager.onHorseAdded:add(HorseModData.initialize)
+---Sets the global horse mod data.
+---@generic T
+---@param horse IsoAnimal
+---@param data table<string, T>
+function HorseModData.setAll(horse, data)
+    local modData = horse:getModData()
+    modData.horseModData = data
+end
+
+---Retrieve all horse mod data.
+---@generic T
+---@param horse IsoAnimal
+---@return table<string, T>
+function HorseModData.getAll(horse)
+    local modData = horse:getModData()
+    modData.horseModData = modData.horseModData or {}
+    return modData.horseModData
+end
+
+function HorseModData.getGlobal()
+    local md = ModData.getOrCreate("HorseMod")
+    md.orphanedHorses = md.orphanedHorses or {}
+    return md
+end
 
 
 return HorseModData

--- a/Contents/mods/HorseMod/42/media/lua/shared/HorseMod/attachments/Attachments.lua
+++ b/Contents/mods/HorseMod/42/media/lua/shared/HorseMod/attachments/Attachments.lua
@@ -21,7 +21,7 @@ local ATTACHMENTS_MOD_DATA = HorseModData.register--[[@<AttachmentsModData>]](
         if not modData.bySlot then
             local breedName = HorseUtils.getBreedName(horse)
             local maneDef = Attachments.getManeDefinition(breedName)
-            local maneConfig = HorseUtils.tableCopy(maneDef.maneConfig)
+            local maneConfig = copyTable(maneDef.maneConfig)
             modData.bySlot = maneConfig -- default mane config
         end
     end

--- a/Contents/mods/HorseMod/42/media/lua/shared/HorseMod/attachments/ContainerManager.lua
+++ b/Contents/mods/HorseMod/42/media/lua/shared/HorseMod/attachments/ContainerManager.lua
@@ -1,7 +1,7 @@
 ---@namespace HorseMod
 
 ---REQUIREMENTS
-local HorseManager = require("HorseMod/HorseManager")
+local EventHandler = require("HorseMod/EventHandler")
 local HorseModData = require("HorseMod/HorseModData")
 
 ---This class holds all the informations needed to find and identify a container attached to a horse, so the world item can be associated to the horse, and the horse can associate itself to the world item. The XYZ coordinates are stored to help find the world item again if needed and this data is added to the world item mod data.
@@ -376,7 +376,7 @@ ContainerManager.track = function(horse)
 end
 
 -- consider horse loses all world item refs
-HorseManager.onHorseRemoved:add(function(horse)
+EventHandler.onHorseRemoved:add(function(horse)
     -- get containers linked to the horse
     local containers = HorseModData.get(horse, CONTAINERS_MOD_DATA)
 

--- a/Contents/mods/HorseMod/42/media/lua/shared/HorseMod/patches/AnimalPickup.lua
+++ b/Contents/mods/HorseMod/42/media/lua/shared/HorseMod/patches/AnimalPickup.lua
@@ -1,0 +1,20 @@
+---@namespace HorseMod
+
+---REQUIREMENTS
+local HorseUtils = require("HorseMod/Utils")
+local HorseManager = require("HorseMod/HorseManager")
+
+local AnimalPickup = {}
+
+AnimalPickup._originalComplete = ISPickupAnimal.complete
+function ISPickupAnimal:complete()
+    local animal = self.animal
+    if animal and HorseUtils.isHorse(animal) then
+        HorseManager.makeOrphan(animal)
+        HorseManager.removeFromHorses(animal)
+    end
+
+    return AnimalPickup._originalComplete(self)
+end
+
+return AnimalPickup


### PR DESCRIPTION
- Patches animal pickup actions to store its mod data in a new orphaned mod data system
- This involved moving event definitions into a new file EventHandler to stop circle requirements
- Added helpers to access global mod data related to the horse mod
- Replaced now removed tableCopy utility with copyTable since it is a deep copy
- Fixed some wrongly named horse IDs that made the translations not apply