### PR TITLE
use event to terminate mount/dismount actions, fixes #213

### DIFF
--- a/Contents/mods/HorseMod/42/media/AnimSets/player/actions/Horse_Dismount_BarebackLeft.xml
+++ b/Contents/mods/HorseMod/42/media/AnimSets/player/actions/Horse_Dismount_BarebackLeft.xml
@@ -24,9 +24,9 @@
         <m_ParameterValue>HorseNoCancel=true</m_ParameterValue>
     </m_Events>
     <m_Events>
-        <m_EventName>SetVariable</m_EventName>
+        <m_EventName>HorseDismountingComplete</m_EventName>
         <m_Time>End</m_Time>
-        <m_ParameterValue>HorseDismountFinished=true</m_ParameterValue>
+        <m_ParameterValue></m_ParameterValue>
     </m_Events>
     <m_Events>
         <m_EventName>SetVariable</m_EventName>

--- a/Contents/mods/HorseMod/42/media/AnimSets/player/actions/Horse_Dismount_BarebackRight.xml
+++ b/Contents/mods/HorseMod/42/media/AnimSets/player/actions/Horse_Dismount_BarebackRight.xml
@@ -24,9 +24,9 @@
         <m_ParameterValue>HorseNoCancel=true</m_ParameterValue>
     </m_Events>
     <m_Events>
-        <m_EventName>SetVariable</m_EventName>
+        <m_EventName>HorseDismountingComplete</m_EventName>
         <m_Time>End</m_Time>
-        <m_ParameterValue>HorseDismountFinished=true</m_ParameterValue>
+        <m_ParameterValue></m_ParameterValue>
     </m_Events>
     <m_Events>
         <m_EventName>SetVariable</m_EventName>

--- a/Contents/mods/HorseMod/42/media/AnimSets/player/actions/Horse_Dismount_SaddleLeft.xml
+++ b/Contents/mods/HorseMod/42/media/AnimSets/player/actions/Horse_Dismount_SaddleLeft.xml
@@ -24,9 +24,9 @@
         <m_ParameterValue>HorseNoCancel=true</m_ParameterValue>
     </m_Events>
     <m_Events>
-        <m_EventName>SetVariable</m_EventName>
+        <m_EventName>HorseDismountingComplete</m_EventName>
         <m_Time>End</m_Time>
-        <m_ParameterValue>HorseDismountFinished=true</m_ParameterValue>
+        <m_ParameterValue></m_ParameterValue>
     </m_Events>
     <m_Events>
         <m_EventName>SetVariable</m_EventName>

--- a/Contents/mods/HorseMod/42/media/AnimSets/player/actions/Horse_Dismount_SaddleRight.xml
+++ b/Contents/mods/HorseMod/42/media/AnimSets/player/actions/Horse_Dismount_SaddleRight.xml
@@ -24,9 +24,9 @@
         <m_ParameterValue>HorseNoCancel=true</m_ParameterValue>
     </m_Events>
     <m_Events>
-        <m_EventName>SetVariable</m_EventName>
+        <m_EventName>HorseDismountingComplete</m_EventName>
         <m_Time>End</m_Time>
-        <m_ParameterValue>HorseDismountFinished=true</m_ParameterValue>
+        <m_ParameterValue></m_ParameterValue>
     </m_Events>
     <m_Events>
         <m_EventName>SetVariable</m_EventName>

--- a/Contents/mods/HorseMod/42/media/AnimSets/player/actions/Horse_Mount_BarebackLeft.xml
+++ b/Contents/mods/HorseMod/42/media/AnimSets/player/actions/Horse_Mount_BarebackLeft.xml
@@ -24,9 +24,9 @@
         <m_ParameterValue>HorseNoCancel=true</m_ParameterValue>
     </m_Events>
     <m_Events>
-        <m_EventName>SetVariable</m_EventName>
+        <m_EventName>HorseMountingComplete</m_EventName>
         <m_Time>End</m_Time>
-        <m_ParameterValue>HorseMountFinished=true</m_ParameterValue>
+        <m_ParameterValue></m_ParameterValue>
     </m_Events>
     <m_SubStateBoneWeights>
         <boneName>Dummy01</boneName>

--- a/Contents/mods/HorseMod/42/media/AnimSets/player/actions/Horse_Mount_BarebackRight.xml
+++ b/Contents/mods/HorseMod/42/media/AnimSets/player/actions/Horse_Mount_BarebackRight.xml
@@ -24,9 +24,9 @@
         <m_ParameterValue>HorseNoCancel=true</m_ParameterValue>
     </m_Events>
     <m_Events>
-        <m_EventName>SetVariable</m_EventName>
+        <m_EventName>HorseMountingComplete</m_EventName>
         <m_Time>End</m_Time>
-        <m_ParameterValue>HorseMountFinished=true</m_ParameterValue>
+        <m_ParameterValue></m_ParameterValue>
     </m_Events>
     <m_SubStateBoneWeights>
         <boneName>Dummy01</boneName>

--- a/Contents/mods/HorseMod/42/media/AnimSets/player/actions/Horse_Mount_SaddleLeft.xml
+++ b/Contents/mods/HorseMod/42/media/AnimSets/player/actions/Horse_Mount_SaddleLeft.xml
@@ -24,9 +24,9 @@
         <m_ParameterValue>HorseNoCancel=true</m_ParameterValue>
     </m_Events>
     <m_Events>
-        <m_EventName>SetVariable</m_EventName>
+        <m_EventName>HorseMountingComplete</m_EventName>
         <m_Time>End</m_Time>
-        <m_ParameterValue>HorseMountFinished=true</m_ParameterValue>
+        <m_ParameterValue></m_ParameterValue>
     </m_Events>
     <m_SubStateBoneWeights>
         <boneName>Dummy01</boneName>

--- a/Contents/mods/HorseMod/42/media/AnimSets/player/actions/Horse_Mount_SaddleRight.xml
+++ b/Contents/mods/HorseMod/42/media/AnimSets/player/actions/Horse_Mount_SaddleRight.xml
@@ -24,9 +24,9 @@
         <m_ParameterValue>HorseNoCancel=true</m_ParameterValue>
     </m_Events>
     <m_Events>
-        <m_EventName>SetVariable</m_EventName>
+        <m_EventName>HorseMountingComplete</m_EventName>
         <m_Time>End</m_Time>
-        <m_ParameterValue>HorseMountFinished=true</m_ParameterValue>
+        <m_ParameterValue></m_ParameterValue>
     </m_Events>
     <m_SubStateBoneWeights>
         <boneName>Dummy01</boneName>

--- a/Contents/mods/HorseMod/42/media/lua/client/HorseMod/Riding.lua
+++ b/Contents/mods/HorseMod/42/media/lua/client/HorseMod/Riding.lua
@@ -163,8 +163,6 @@ Events.OnCharacterDeath.Add(HorseRiding.dismountOnHorseDeath)
 local function initHorseMod(_, player)
     player:setVariable(AnimationVariable.RIDING_HORSE, false)
     player:setVariable(AnimationVariable.MOUNTING_HORSE, false)
-    player:setVariable(AnimationVariable.DISMOUNT_FINISHED, false)
-    player:setVariable(AnimationVariable.MOUNT_FINISHED, false)
 end
 
 Events.OnCreatePlayer.Add(initHorseMod)

--- a/Contents/mods/HorseMod/42/media/lua/shared/HorseMod/definitions/AnimationEvent.lua
+++ b/Contents/mods/HorseMod/42/media/lua/shared/HorseMod/definitions/AnimationEvent.lua
@@ -1,0 +1,9 @@
+---@namespace HorseMod
+
+---@enum AnimEvent
+local AnimEvent = {
+    MOUNTING_COMPLETE = "HorseMountingComplete",
+    DISMOUNTING_COMPLETE = "HorseDismountingComplete"
+}
+
+return AnimEvent

--- a/Contents/mods/HorseMod/42/media/lua/shared/HorseMod/definitions/AnimationVariable.lua
+++ b/Contents/mods/HorseMod/42/media/lua/shared/HorseMod/definitions/AnimationVariable.lua
@@ -14,9 +14,7 @@ local AnimationVariable = {
     -- Activates mounted player animations while true
     RIDING_HORSE = "HorseRiding",
     MOUNTING_HORSE = "HorseMountingHorse",
-    MOUNT_FINISHED = "HorseMountFinished",
     DISMOUNT_STARTED = "HorseDismountStarted",
-    DISMOUNT_FINISHED = "HorseDismountFinished",
     NO_CANCEL = "HorseNoCancel",
 
     HAS_REINS = "HorseHasReins",


### PR DESCRIPTION
Changes the mounting actions to use an animation event rather than constantly polling an animation variable. Fixes #213. Urgent dismounts have not been changed: they will need more major changes to work in multiplayer.