### PR TITLE
Update docs workflow to actually publish the docs

### DIFF
--- a/.github/workflows/deployDocs.yml
+++ b/.github/workflows/deployDocs.yml
@@ -8,6 +8,7 @@ on:
       - 'docs/**'
       - '*.lua'
   pull_request:
+  workflow_dispatch:
 
 jobs:
   build:
@@ -33,14 +34,14 @@ jobs:
           make html
 
       - name: Upload artifact
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
         uses: actions/upload-pages-artifact@v4.0.0
         with:
           path: docs/build/html
 
   deploy:
     needs: build
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
 
     permissions:
       pages: write


### PR DESCRIPTION
Merge after the repo is made public. If I'm not personally around to do this, you will probably need to go into the repository settings to enable pages.