### PR TITLE
Correct Filly -> Foal animal name

### DIFF
--- a/Contents/mods/HorseMod/common/media/lua/shared/Translate/EN/IG_UI.json
+++ b/Contents/mods/HorseMod/common/media/lua/shared/Translate/EN/IG_UI.json
@@ -1,7 +1,7 @@
 {
     "IGUI_AnimalType_stallion": "Stallion",
     "IGUI_AnimalType_mare": "Mare",
-    "IGUI_AnimalType_filly": "Filly",
+    "IGUI_AnimalType_filly": "Foal",
     "IGUI_AnimalType_Global_horse": "Horse",
     "IGUI_Animal_Group_horse": "Horse",
     "IGUI_Horse_Slot": "Slot",


### PR DESCRIPTION
Changes the English name of baby horses from 'filly' to the correct gender neutral 'foal'.