### PR TITLE
Harden mounted riding sync for multiplayer

### DIFF
--- a/Contents/mods/HorseMod/42/media/AnimSets/buck/idle/Horse_Mounted_PathfindWalk.xml
+++ b/Contents/mods/HorseMod/42/media/AnimSets/buck/idle/Horse_Mounted_PathfindWalk.xml
@@ -25,6 +25,16 @@
         <m_Type>BOOL</m_Type>
         <m_BoolValue>true</m_BoolValue>
     </m_Conditions>
+    <m_Conditions>
+        <m_Name>mountedTwist</m_Name>
+        <m_Type>LESS</m_Type>
+        <m_Value>30</m_Value>
+    </m_Conditions>
+    <m_Conditions>
+        <m_Name>mountedTwist</m_Name>
+        <m_Type>GTR</m_Type>
+        <m_Value>-30</m_Value>
+    </m_Conditions>
     <m_Transitions>
         <m_Target>Horse_Mounted_Wait</m_Target>
         <m_blendInTime>0.80</m_blendInTime>

--- a/Contents/mods/HorseMod/42/media/AnimSets/buck/idle/Horse_Mounted_WalkTurnLeft.xml
+++ b/Contents/mods/HorseMod/42/media/AnimSets/buck/idle/Horse_Mounted_WalkTurnLeft.xml
@@ -32,6 +32,11 @@
         <m_Type>BOOL</m_Type>
         <m_BoolValue>false</m_BoolValue>
     </m_Conditions>
+    <m_Conditions>
+        <m_Name>mountedTwist</m_Name>
+        <m_Type>LESS</m_Type>
+        <m_Value>-30</m_Value>
+    </m_Conditions>
     <m_Transitions>
         <m_Target>Horse_Mounted_Run</m_Target>
         <m_blendInTime>0.80</m_blendInTime>

--- a/Contents/mods/HorseMod/42/media/AnimSets/buck/idle/Horse_Mounted_WalkTurnRight.xml
+++ b/Contents/mods/HorseMod/42/media/AnimSets/buck/idle/Horse_Mounted_WalkTurnRight.xml
@@ -32,6 +32,11 @@
         <m_Type>BOOL</m_Type>
         <m_BoolValue>false</m_BoolValue>
     </m_Conditions>
+    <m_Conditions>
+        <m_Name>mountedTwist</m_Name>
+        <m_Type>GTR</m_Type>
+        <m_Value>30</m_Value>
+    </m_Conditions>
     <m_Transitions>
         <m_Target>Horse_Mounted_Run</m_Target>
         <m_blendInTime>0.80</m_blendInTime>

--- a/Contents/mods/HorseMod/42/media/AnimSets/buck/walk/Horse_TrotMounted.xml
+++ b/Contents/mods/HorseMod/42/media/AnimSets/buck/walk/Horse_TrotMounted.xml
@@ -122,11 +122,6 @@
         <m_ParameterValue>isTurningRight=false</m_ParameterValue>
     </m_Events>
     <m_Conditions>
-        <m_Name>animalRunning</m_Name>
-        <m_Type>BOOL</m_Type>
-        <m_BoolValue>true</m_BoolValue>
-    </m_Conditions>
-    <m_Conditions>
         <m_Name>HorseRiding</m_Name>
         <m_Type>BOOL</m_Type>
         <m_Value>true</m_Value>

--- a/Contents/mods/HorseMod/42/media/AnimSets/buck/walk/Horse_WalkMounted.xml
+++ b/Contents/mods/HorseMod/42/media/AnimSets/buck/walk/Horse_WalkMounted.xml
@@ -97,11 +97,6 @@
         <m_ParameterValue>GallopToIdlePlayer=false</m_ParameterValue>
     </m_Events>
     <m_Conditions>
-        <m_Name>animalRunning</m_Name>
-        <m_Type>BOOL</m_Type>
-        <m_BoolValue>true</m_BoolValue>
-    </m_Conditions>
-    <m_Conditions>
         <m_Name>HorseRiding</m_Name>
         <m_Type>BOOL</m_Type>
         <m_Value>true</m_Value>

--- a/Contents/mods/HorseMod/42/media/lua/client/HorseMod/Riding.lua
+++ b/Contents/mods/HorseMod/42/media/lua/client/HorseMod/Riding.lua
@@ -13,8 +13,12 @@ local MountingUtility = require("HorseMod/mounting/MountingUtility")
 local HorseManager = require("HorseMod/HorseManager")
 local RemoteMountInterp = require("HorseMod/mount/RemoteMountInterp")
 require("HorseMod/mount/RemoteRiderPin")
+local PendingRidingState = require("HorseMod/mount/PendingRidingState")
 local mountcommands = require("HorseMod/networking/mountcommands")
 local commands = require("HorseMod/networking/commands")
+local netmetrics = require("HorseMod/networking/netmetrics")
+local relevance = require("HorseMod/networking/relevance")
+local ridingcodec = require("HorseMod/networking/ridingcodec")
 
 
 ---@namespace HorseMod
@@ -97,6 +101,14 @@ end)
 ---@param player IsoPlayer
 ---@param dismountedAnimal IsoAnimal?
 Mounts.onDismount:add(function(player, dismountedAnimal)
+    HorseRiding.lastAppliedState[player] = nil
+    if dismountedAnimal then
+        PendingRidingState.clear(
+            ridingcodec.encodePlayerId(player),
+            commands.getAnimalId(dismountedAnimal)
+        )
+    end
+
     if not player:isLocalPlayer() then
         RemoteMountInterp.clear(player)
         return
@@ -106,6 +118,50 @@ Mounts.onDismount:add(function(player, dismountedAnimal)
         HorseRiding.removeMount(player)
     end
 end)
+
+---Newest riding-state sequence applied per rider, used to drop duplicate and
+---out-of-order snapshots. Command packets are reliable but not ordered.
+---@type table<IsoPlayer, {animal: integer, seq: integer}>
+HorseRiding.lastAppliedState = {}
+
+---@param args RidingStateArguments
+---@return boolean applied
+local function applyResolvedState(args)
+    local player = ridingcodec.decodePlayerId(args.character)
+    local animal = commands.getAnimal(args.animal)
+    if not player or not animal then
+        return false
+    end
+
+    local tracked = HorseRiding.lastAppliedState[player]
+    if tracked and tracked.animal == args.animal and args.seq <= tracked.seq then
+        if netmetrics.enabled then
+            netmetrics.count("riding.clientStaleRejected")
+        end
+        return true
+    end
+
+    if player:isLocalPlayer() then
+        local mount = HorseRiding.getMount(player)
+        if not mount then
+            return false
+        end
+        mount:applyAuthoritativeState(args)
+    else
+        RemoteMountInterp.push(player, animal, args)
+    end
+
+    if tracked and tracked.animal == args.animal then
+        tracked.seq = args.seq
+    else
+        HorseRiding.lastAppliedState[player] = {
+            animal = args.animal,
+            seq = args.seq,
+        }
+    end
+
+    return true
+end
 
 ---Update the horse riding for every mounts.
 local function updateMounts()
@@ -118,27 +174,28 @@ local function updateMounts()
             end
         end
     end
+
+    PendingRidingState.flush(applyResolvedState)
 end
 
 HorseManager.preUpdate:add(updateMounts)
 
----@param args RidingStateArguments
-local function applyRidingState(args)
-    local player = commands.getPlayer(args.character)
-    local animal = commands.getAnimal(args.animal)
-    if not player or not animal then
-        return
-    end
-
-    if player:isLocalPlayer() then
-        local mount = HorseRiding.getMount(player)
-        if mount then
-            mount:applyAuthoritativeState(args)
+---@param wire RidingStateWire
+local function applyRidingState(wire)
+    local args = ridingcodec.decode(wire)
+    if not args then
+        if netmetrics.enabled then
+            netmetrics.count("riding.clientDecodeRejected")
         end
         return
     end
 
-    RemoteMountInterp.push(player, animal, args)
+    if not applyResolvedState(args) then
+        PendingRidingState.store(args)
+        if netmetrics.enabled then
+            netmetrics.count("riding.clientPendingStored")
+        end
+    end
 end
 
 Events.OnInitGlobalModData.Add(function()
@@ -227,7 +284,13 @@ local function initHorseMod(_, player)
     player:setVariable(AnimationVariable.MOUNTING_HORSE, false)
 
     if isClient() then
-        mountcommands.RequestMounts:send(player, {})
+        PendingRidingState.clearAll()
+        mountcommands.RequestMounts:send(
+            player,
+            {
+                w = relevance.getLocalChunkGridWidth(),
+            }
+        )
     elseif isServer() then
         return
     else

--- a/Contents/mods/HorseMod/42/media/lua/client/HorseMod/mount/PendingRidingState.lua
+++ b/Contents/mods/HorseMod/42/media/lua/client/HorseMod/mount/PendingRidingState.lua
@@ -1,0 +1,109 @@
+---@namespace HorseMod
+
+---Holds riding snapshots whose rider or animal has not streamed in yet.
+---The relevance approximation on the server cannot see the engine's real
+---connect areas, so a snapshot can legitimately arrive a moment early.
+local PendingRidingState = {}
+
+local MAX_ENTRIES = 32
+local EXPIRY_MS = 3000
+
+---@class PendingRidingEntry
+---@field args RidingStateArguments
+---@field stamp integer
+
+---@type table<string, PendingRidingEntry>
+local pending = {}
+local pendingCount = 0
+
+---@param args RidingStateArguments
+---@return string
+---@nodiscard
+local function makeKey(args)
+    return args.character .. ":" .. args.animal
+end
+
+local function dropOldest()
+    local oldestKey = nil
+    local oldestStamp = nil
+
+    for key, entry in pairs(pending) do
+        if not oldestStamp or entry.stamp < oldestStamp then
+            oldestStamp = entry.stamp
+            oldestKey = key
+        end
+    end
+
+    if oldestKey then
+        pending[oldestKey] = nil
+        pendingCount = pendingCount - 1
+    end
+end
+
+---@param args RidingStateArguments
+function PendingRidingState.store(args)
+    local key = makeKey(args)
+    local entry = pending[key]
+
+    if entry then
+        if args.seq < entry.args.seq then
+            return
+        end
+        entry.args = args
+        entry.stamp = getTimestampMs()
+        return
+    end
+
+    if pendingCount >= MAX_ENTRIES then
+        dropOldest()
+    end
+
+    pending[key] = {
+        args = args,
+        stamp = getTimestampMs(),
+    }
+    pendingCount = pendingCount + 1
+end
+
+---@param character integer
+---@param animal integer
+function PendingRidingState.clear(character, animal)
+    local key = character .. ":" .. animal
+    if pending[key] then
+        pending[key] = nil
+        pendingCount = pendingCount - 1
+    end
+end
+
+function PendingRidingState.clearAll()
+    pending = {}
+    pendingCount = 0
+end
+
+---Retries every held snapshot. The resolver returns true once it has applied
+---the snapshot, which retires the entry.
+---@param resolve fun(args: RidingStateArguments): boolean
+function PendingRidingState.flush(resolve)
+    if pendingCount == 0 then
+        return
+    end
+
+    local now = getTimestampMs()
+    for key, entry in pairs(pending) do
+        if now - entry.stamp > EXPIRY_MS then
+            pending[key] = nil
+            pendingCount = pendingCount - 1
+        elseif resolve(entry.args) then
+            pending[key] = nil
+            pendingCount = pendingCount - 1
+        end
+    end
+end
+
+---@return integer
+---@nodiscard
+function PendingRidingState.getCount()
+    return pendingCount
+end
+
+return PendingRidingState

--- a/Contents/mods/HorseMod/42/media/lua/client/HorseMod/mount/RemoteMountInterp.lua
+++ b/Contents/mods/HorseMod/42/media/lua/client/HorseMod/mount/RemoteMountInterp.lua
@@ -31,8 +31,11 @@ local RemoteMountInterp = {}
 local MIN_INTERVAL = 0.02
 local MAX_INTERVAL = 0.5
 local EXTRAPOLATE_LIMIT = 1.1
-local STALE_SECONDS = 1.0
+-- Must stay well clear of the server's one second stationary heartbeat, or a
+-- single late packet stops a parked rider being reasserted.
+local STALE_SECONDS = 3.0
 local MOUNTED_TURN_DELTA = 0.65
+
 
 ---@type table<IsoPlayer, RemoteMountEntry>
 local entries = {}
@@ -103,7 +106,6 @@ local function applyAnimVars(rider, animal, args)
     rider:setVariable(AnimationVariable.TROT, trotting)
     rider:setVariable(AnimationVariable.JUMP, jumping)
 
-    MountedAnimationState.setSpeedVariables(rider, animal)
     MountedAnimationState.setMovementVariables(rider, animal, moving, galloping)
     MountedAnimationState.setTurnVariables(rider, animal, getTurnFromArgs(args))
     MountedAnimationState.setReinsVariable(rider, args.hasReins == true)
@@ -140,6 +142,8 @@ function RemoteMountInterp.push(rider, animal, args)
             lastArgs = args,
         }
         entries[rider] = entry
+        Mounts.setInterpolated(rider, true)
+        MountedAnimationState.setSpeedVariables(rider, animal)
         animal:setX(snapshot.x)
         animal:setY(snapshot.y)
         animal:setZ(snapshot.z)
@@ -172,7 +176,16 @@ function RemoteMountInterp.push(rider, animal, args)
     entry.timeSinceNext = 0
     entry.timeSinceAnyPush = 0
     entry.lastArgs = args
+    prepareRemoteMount(animal, args.speed > 0)
+    MountedAnimationState.setSpeedVariables(rider, animal)
     applyAnimVars(rider, animal, args)
+    RemoteRiderPin.pinRiderToPosition(
+        rider,
+        snapshot.x,
+        snapshot.y,
+        snapshot.z,
+        IsoDirections.fromIndex(snapshot.dir)
+    )
 end
 
 ---@param rider IsoPlayer
@@ -182,6 +195,7 @@ function RemoteMountInterp.clear(rider)
         MountedDirection.clear(entry.animal)
     end
     entries[rider] = nil
+    Mounts.setInterpolated(rider, false)
 end
 
 local function update()
@@ -194,6 +208,7 @@ local function update()
                 MountedDirection.clear(animal)
             end
             entries[rider] = nil
+            Mounts.setInterpolated(rider, false)
             break
         end
 
@@ -206,6 +221,10 @@ local function update()
 
         local target = entry.next
         local source = entry.prev or target
+
+        -- Every frame, not on a timer: the vanilla state machine clobbers these
+        -- continuously, and a remote rider reverts to on-foot animation the moment
+        -- they go unasserted.
         prepareRemoteMount(animal, target.speed > 0)
         applyAnimVars(rider, animal, entry.lastArgs)
 

--- a/Contents/mods/HorseMod/42/media/lua/client/HorseMod/mount/RemoteRiderPin.lua
+++ b/Contents/mods/HorseMod/42/media/lua/client/HorseMod/mount/RemoteRiderPin.lua
@@ -8,6 +8,7 @@ local RemoteRiderPin = {}
 
 local MAX_PIN_Z_DELTA = 2
 
+
 ---@param rider IsoPlayer
 local function keepRemoteRiderLocked(rider)
     if not rider:getIgnoreMovement() then
@@ -51,6 +52,10 @@ end
 ---@param rider IsoPlayer
 ---@param animal IsoAnimal
 function RemoteRiderPin.pinRiderToAnimal(rider, animal)
+    if Mounts.isInterpolated(rider) then
+        return
+    end
+
     if rider:isLocalPlayer() then
         return
     end

--- a/Contents/mods/HorseMod/42/media/lua/server/HorseMod/riding/ServerRiding.lua
+++ b/Contents/mods/HorseMod/42/media/lua/server/HorseMod/riding/ServerRiding.lua
@@ -12,10 +12,12 @@ local MountedDirection = require("HorseMod/riding/MountedDirection")
 local mountcommands = require("HorseMod/networking/mountcommands")
 local soundcommands = require("HorseMod/networking/soundcommands")
 local commands = require("HorseMod/networking/commands")
+local netmetrics = require("HorseMod/networking/netmetrics")
+local relevance = require("HorseMod/networking/relevance")
+local ridingcodec = require("HorseMod/networking/ridingcodec")
 local server = require("HorseMod/networking/server")
 
 local INPUT_TIMEOUT_SECONDS = 0.35
-local HEARTBEAT_INTERVAL_SECONDS = 0.25
 local JUMP_COOLDOWN_MS = 1200
 local RESYNC_SEQ_GAP = 30
 local MAX_MOUNT_DISTANCE_SQ = 144
@@ -26,10 +28,23 @@ local MAX_CLIENT_Z_DELTA = 2
 local TURN_ANIM_HOLD_SECONDS = 0.20
 local IDLE_TO_RUN_SECONDS = 0.6
 
+-- A dedicated server ticks around 10 Hz with a per-tick delta near 0.1, so an
+-- interval of 0.1 needs TWO ticks and silently halves the rate. Keep these under
+-- one tick period so the threshold is met on the tick it is due.
+local ROUTE_INTERVAL_SECONDS = 0.05
+local MOVING_SEND_INTERVAL_SECONDS = 0.1
+-- Trot and gallop both cover enough ground per snapshot that 5 Hz reads as
+-- teleporting. Walking still looks fine at the slower rate.
+local FAST_SEND_INTERVAL_SECONDS = 0.05
+local IDLE_SEND_INTERVAL_SECONDS = 1.0
+local RANGE_SWEEP_INTERVAL_SECONDS = 1.0
+local ONLINE_CACHE_MS = 50
+
 ---@class ServerRidingState
 ---@field rider IsoPlayer
 ---@field animal IsoAnimal
 ---@field seq integer
+---@field outSeq integer
 ---@field lastSpeed number
 ---@field lastGallop boolean
 ---@field lastTrot boolean
@@ -42,11 +57,33 @@ local IDLE_TO_RUN_SECONDS = 0.6
 ---@field lastHasReins boolean
 ---@field lastGait MovementState
 ---@field timeSinceInput number
----@field timeSinceHeartbeat number
+---@field timeSinceRoute number
+---@field timeSinceSend number
 ---@field idleToRunTime number
+---@field semanticDirty boolean
+---@field sentX number
+---@field sentY number
+---@field sentZ number
+---@field routePass integer
+---@field observers table<IsoPlayer, integer>
 
 ---@type table<IsoPlayer, ServerRidingState>
 local states = {}
+
+---Approximated relevance range in tiles, reported by each client on join.
+---@type table<IsoPlayer, integer>
+local playerRanges = {}
+
+---@type IsoPlayer[]
+local onlineScratch = {}
+local onlineCount = 0
+local onlineCacheStamp = 0
+
+---@type table<IsoPlayer, true>
+local onlineSetScratch = {}
+
+local rangeSweepTimer = 0
+local routeStagger = 0
 
 ---@class ClientRidingPose
 ---@field x number
@@ -57,6 +94,44 @@ local states = {}
 
 ---@class ValidatedRidingInput : RidingMovementInput
 ---@field hasReins boolean
+
+local function refreshOnlinePlayers()
+    local now = getTimestampMs()
+    if now - onlineCacheStamp < ONLINE_CACHE_MS then
+        return
+    end
+    onlineCacheStamp = now
+
+    local previousCount = onlineCount
+    onlineCount = 0
+
+    local players = getOnlinePlayers()
+    if players then
+        for i = 0, players:size() - 1 do
+            local player = players:get(i)
+            if player then
+                onlineCount = onlineCount + 1
+                onlineScratch[onlineCount] = player
+            end
+        end
+    end
+
+    for i = onlineCount + 1, previousCount do
+        onlineScratch[i] = nil
+    end
+end
+
+---@param player IsoPlayer
+---@return integer
+---@nodiscard
+local function getRelevanceRange(player)
+    local range = playerRanges[player]
+    if not range then
+        return relevance.MAX_RANGE_TILES
+    end
+
+    return range
+end
 
 ---@param value any
 ---@return number?
@@ -235,18 +310,85 @@ end
 ---@param state ServerRidingState
 ---@param gait MovementState
 ---@param jumping boolean
+---@return HorseSoundStateArguments
+---@nodiscard
+local function buildGaitArgs(state, gait, jumping)
+    return {
+        rider = commands.getPlayerId(state.rider),
+        animal = commands.getAnimalId(state.animal),
+        gait = gait,
+        jumping = jumping,
+    }
+end
+
+---Only observers that can load the horse can do anything with a gait change;
+---everyone else drops the packet after resolving the animal to nil.
+---@param state ServerRidingState
+---@param gait MovementState
+---@param jumping boolean
+local function sendGaitToObservers(state, gait, jumping)
+    local args = nil
+    for player in pairs(state.observers) do
+        if not args then
+            args = buildGaitArgs(state, gait, jumping)
+        end
+        soundcommands.HorseSoundState:send(player, args)
+    end
+end
+
+---@param state ServerRidingState
+---@param player IsoPlayer
+local function sendGaitToObserver(state, player)
+    soundcommands.HorseSoundState:send(
+        player,
+        buildGaitArgs(state, state.lastGait, state.lastJump)
+    )
+end
+
+---@param state ServerRidingState
+---@param gait MovementState
+---@param jumping boolean
 local function broadcastGaitIfChanged(state, gait, jumping)
     if state.lastGait == gait then
         return
     end
     state.lastGait = gait
 
-    soundcommands.HorseSoundState:send(nil--[[@as IsoPlayer?]], {
-        rider = commands.getPlayerId(state.rider),
-        animal = commands.getAnimalId(state.animal),
-        gait = gait,
-        jumping = jumping,
-    })
+    sendGaitToObservers(state, gait, jumping)
+end
+
+---Everything a remote observer needs immediately, with direction and position
+---left out because those follow the movement cadence instead.
+---@param state ServerRidingState
+---@return integer
+---@nodiscard
+local function semanticSignature(state)
+    local turn = 0
+    if state.lastTurnTime > 0 then
+        turn = state.lastTurn
+    end
+
+    local signature = turn + 1
+    if state.lastGallop then
+        signature = signature + 4
+    end
+    if state.lastTrot then
+        signature = signature + 8
+    end
+    if state.lastJump then
+        signature = signature + 16
+    end
+    if state.lastHasReins then
+        signature = signature + 32
+    end
+    if state.lastMoving then
+        signature = signature + 64
+    end
+    if (not state.lastGallop) or state.idleToRunTime > 0 then
+        signature = signature + 128
+    end
+
+    return signature
 end
 
 ---@param state ServerRidingState
@@ -255,6 +397,7 @@ end
 local function applyClientPose(state, input, pose)
     local animal = state.animal
     local rider = state.rider
+    local previousSignature = semanticSignature(state)
 
     animal:setX(pose.x)
     animal:setY(pose.y)
@@ -309,12 +452,16 @@ local function applyClientPose(state, input, pose)
     state.lastDir = pose.dir
     state.lastHasReins = input.hasReins
 
+    if semanticSignature(state) ~= previousSignature then
+        state.semanticDirty = true
+    end
+
     broadcastGaitIfChanged(state, deriveGait(moving, galloping, input.trot == true), input.jump == true)
 end
 
+---Builds a complete snapshot and consumes one outbound sequence number.
 ---@param state ServerRidingState
 ---@return RidingStateArguments
----@nodiscard
 local function buildStateArgs(state)
     local animal = state.animal
     local turn = 0
@@ -322,10 +469,16 @@ local function buildStateArgs(state)
         turn = state.lastTurn
     end
 
+    state.outSeq = state.outSeq + 1
+
+    if netmetrics.enabled then
+        netmetrics.count("riding.snapshotsBuilt")
+    end
+
     return {
-        character = commands.getPlayerId(state.rider),
+        character = ridingcodec.encodePlayerId(state.rider),
         animal = commands.getAnimalId(animal),
-        seq = state.seq,
+        seq = state.outSeq,
         x = animal:getX(),
         y = animal:getY(),
         z = animal:getZ(),
@@ -340,21 +493,87 @@ local function buildStateArgs(state)
     }
 end
 
+---Sends a complete snapshot to every observer that can currently load the
+---horse. Observers that only just entered the relevance area are always served,
+---even when the cadence has nothing else to say.
 ---@param state ServerRidingState
----@param excludeRider boolean
-local function relayRidingState(state, excludeRider)
-    local args = buildStateArgs(state)
+---@param reason string? Nil sends to newly relevant observers only.
+local function routeRidingState(state, reason)
     local rider = state.rider
+    local animal = state.animal
+    local animalX = animal:getX()
+    local animalY = animal:getY()
+    local observers = state.observers
+    local metricsEnabled = netmetrics.enabled
 
-    local players = getOnlinePlayers()
-    for i = 0, players:size() - 1 do
-        local player = players:get(i)
-        if not excludeRider or player ~= rider then
-            mountcommands.RidingState:send(player, args)
+    local pass = state.routePass + 1
+    state.routePass = pass
+
+    refreshOnlinePlayers()
+
+    ---@type RidingStateWire?
+    local wire = nil
+    local relevantCount = 0
+    local sentCount = 0
+
+    for i = 1, onlineCount do
+        local player = onlineScratch[i]
+        if player ~= rider then
+            local inRange = relevance.isInRange(
+                animalX,
+                animalY,
+                player:getX(),
+                player:getY(),
+                getRelevanceRange(player)
+            )
+
+            if inRange then
+                relevantCount = relevantCount + 1
+                local isNewObserver = observers[player] == nil
+                observers[player] = pass
+
+                if isNewObserver or reason then
+                    if not wire then
+                        wire = ridingcodec.encode(buildStateArgs(state))
+                    end
+                    mountcommands.RidingState:send(player, wire)
+                    sentCount = sentCount + 1
+
+                    if isNewObserver and state.lastGait ~= "idle" then
+                        sendGaitToObserver(state, player)
+                    end
+
+                    if metricsEnabled then
+                        if isNewObserver then
+                            netmetrics.count("riding.send.entry")
+                        else
+                            netmetrics.count("riding.send." .. reason)
+                        end
+                    end
+                end
+            end
         end
     end
 
-    state.timeSinceHeartbeat = 0
+    for player, seenPass in pairs(observers) do
+        if seenPass ~= pass then
+            observers[player] = nil
+        end
+    end
+
+    if reason then
+        state.semanticDirty = false
+        state.timeSinceSend = 0
+        state.sentX = animalX
+        state.sentY = animalY
+        state.sentZ = animal:getZ()
+    end
+
+    if metricsEnabled then
+        netmetrics.count("riding.candidatesChecked", onlineCount)
+        netmetrics.count("riding.observersRelevant", relevantCount)
+        netmetrics.count("riding.packetsSent", sentCount)
+    end
 end
 
 ---@param player IsoPlayer
@@ -366,10 +585,13 @@ local function getOrCreateState(player, animal)
         return state
     end
 
+    routeStagger = (routeStagger + 1) % 6
+
     state = {
         rider = player,
         animal = animal,
         seq = 0,
+        outSeq = 0,
         lastSpeed = 0,
         lastGallop = false,
         lastTrot = animal:getVariableBoolean(AnimationVariable.TROT),
@@ -382,8 +604,15 @@ local function getOrCreateState(player, animal)
         lastHasReins = player:getVariableBoolean(AnimationVariable.HAS_REINS),
         lastGait = "idle",
         timeSinceInput = INPUT_TIMEOUT_SECONDS,
-        timeSinceHeartbeat = 0,
+        timeSinceRoute = routeStagger * (ROUTE_INTERVAL_SECONDS / 6),
+        timeSinceSend = IDLE_SEND_INTERVAL_SECONDS,
         idleToRunTime = 0.0,
+        semanticDirty = false,
+        sentX = animal:getX(),
+        sentY = animal:getY(),
+        sentZ = animal:getZ(),
+        routePass = 0,
+        observers = {},
     }
     states[player] = state
 
@@ -393,13 +622,23 @@ end
 ---@param player IsoPlayer
 ---@param args RidingInputArguments
 local function handleRidingInput(player, args)
+    if netmetrics.enabled then
+        netmetrics.count("riding.inputsReceived")
+    end
+
     local animal, input, seq, pose = validateInput(player, args)
     if not animal or not input or not seq or not pose then
+        if netmetrics.enabled then
+            netmetrics.count("riding.inputsInvalid")
+        end
         return
     end
 
     local state = getOrCreateState(player, animal)
     if seq < state.seq then
+        if netmetrics.enabled then
+            netmetrics.count("riding.inputsStale")
+        end
         return
     end
 
@@ -408,27 +647,91 @@ local function handleRidingInput(player, args)
     state.timeSinceInput = 0
     applyClientPose(state, input, pose)
 
-    if gap > RESYNC_SEQ_GAP then
-        mountcommands.RidingState:send(player, buildStateArgs(state))
+    if netmetrics.enabled then
+        netmetrics.count("riding.inputsAccepted")
     end
 
-    relayRidingState(state, true)
+    if gap > RESYNC_SEQ_GAP then
+        mountcommands.RidingState:send(player, ridingcodec.encode(buildStateArgs(state)))
+    end
+
+    if state.semanticDirty then
+        routeRidingState(state, "semantic")
+    end
 end
 
 ---@param player IsoPlayer
 ---@param args RequestMountsArguments
 local function handleRequestMounts(player, args)
+    playerRanges[player] = relevance.sanitizeReportedWidth(args.w)
+
     Mounts.sendMounts(player)
 
+    local range = playerRanges[player]
+    local playerX = player:getX()
+    local playerY = player:getY()
+
     Mounts.forEachLoadedMount(function(mountedPlayer, animal)
+        local isSelf = mountedPlayer == player
+        if not isSelf and not relevance.isInRange(animal:getX(), animal:getY(), playerX, playerY, range) then
+            return
+        end
+
         local state = getOrCreateState(mountedPlayer, animal)
-        mountcommands.RidingState:send(player, buildStateArgs(state))
+        if not isSelf then
+            state.observers[player] = state.routePass
+        end
+        mountcommands.RidingState:send(player, ridingcodec.encode(buildStateArgs(state)))
     end)
 end
 
+local function sweepRelevanceRanges()
+    refreshOnlinePlayers()
+
+    for player in pairs(onlineSetScratch) do
+        onlineSetScratch[player] = nil
+    end
+
+    for i = 1, onlineCount do
+        onlineSetScratch[onlineScratch[i]] = true
+    end
+
+    for player in pairs(playerRanges) do
+        if not onlineSetScratch[player] then
+            playerRanges[player] = nil
+        end
+    end
+end
+
+---@param state ServerRidingState
+---@return number
+---@nodiscard
+local function movingSendInterval(state)
+    if state.lastGallop or state.lastTrot then
+        return FAST_SEND_INTERVAL_SECONDS
+    end
+
+    return MOVING_SEND_INTERVAL_SECONDS
+end
+
+---@param state ServerRidingState
+---@return boolean
+---@nodiscard
+local function hasPositionChanged(state)
+    local animal = state.animal
+    return animal:getX() ~= state.sentX
+        or animal:getY() ~= state.sentY
+        or animal:getZ() ~= state.sentZ
+end
 
 local function updateMountedMovement()
     local delta = GameTime.getInstance():getTimeDelta()
+
+    rangeSweepTimer = rangeSweepTimer + delta
+    if rangeSweepTimer >= RANGE_SWEEP_INTERVAL_SECONDS then
+        rangeSweepTimer = 0
+        sweepRelevanceRanges()
+    end
 
     for player, state in pairs(states) do repeat
         local animal = Mounts.getMount(player)
@@ -438,12 +741,14 @@ local function updateMountedMovement()
         end
 
         state.timeSinceInput = state.timeSinceInput + delta
-        state.timeSinceHeartbeat = state.timeSinceHeartbeat + delta
+        state.timeSinceRoute = state.timeSinceRoute + delta
+        state.timeSinceSend = state.timeSinceSend + delta
         if state.lastTurnTime > 0 then
             state.lastTurnTime = math.max(0, state.lastTurnTime - delta)
             if state.lastTurnTime == 0 then
                 state.lastTurn = 0
                 MountedAnimationState.setTurnVariables(state.rider, animal, 0)
+                state.semanticDirty = true
             end
         end
         if state.idleToRunTime > 0 then
@@ -465,11 +770,27 @@ local function updateMountedMovement()
             state.lastTurn = 0
             state.lastTurnTime = 0
             state.idleToRunTime = 0
+            state.timeSinceRoute = 0
             broadcastGaitIfChanged(state, "idle", false)
-            relayRidingState(state, true)
-        elseif state.timeSinceHeartbeat >= HEARTBEAT_INTERVAL_SECONDS then
-            relayRidingState(state, true)
+            routeRidingState(state, "timeout")
+            break
         end
+
+        if state.timeSinceRoute < ROUTE_INTERVAL_SECONDS then
+            break
+        end
+        state.timeSinceRoute = 0
+
+        local reason = nil
+        if state.semanticDirty then
+            reason = "semantic"
+        elseif hasPositionChanged(state) and state.timeSinceSend >= movingSendInterval(state) then
+            reason = "movement"
+        elseif state.timeSinceSend >= IDLE_SEND_INTERVAL_SECONDS then
+            reason = "heartbeat"
+        end
+
+        routeRidingState(state, reason)
     until true end
 end
 
@@ -567,12 +888,7 @@ local function handleDismount(player, animal)
     if state and animal then
         -- Push a final idle so remote clients silence the footstep loop even
         -- if they haven't yet received the Dismount packet.
-        soundcommands.HorseSoundState:send(nil--[[@as IsoPlayer?]], {
-            rider = commands.getPlayerId(player),
-            animal = commands.getAnimalId(animal),
-            gait = "idle",
-            jumping = false,
-        })
+        broadcastGaitIfChanged(state, "idle", false)
     end
     states[player] = nil
 end

--- a/Contents/mods/HorseMod/42/media/lua/shared/HorseMod/Mounts.lua
+++ b/Contents/mods/HorseMod/42/media/lua/shared/HorseMod/Mounts.lua
@@ -31,7 +31,29 @@ local mountedAnimalLockTicks = {}
 ---@type table<IsoPlayer, integer>
 local lastDismountTimestamps = {}
 
+---Riders whose transform and locks are already driven every frame by the remote
+---interpolator. Re-running the generic mount sweep over them is duplicated work.
+---@type table<IsoPlayer, true>
+local interpolatedRiders = {}
+
 local Mounts = {}
+
+---@param rider IsoPlayer
+---@param isInterpolated boolean
+function Mounts.setInterpolated(rider, isInterpolated)
+    if isInterpolated then
+        interpolatedRiders[rider] = true
+    else
+        interpolatedRiders[rider] = nil
+    end
+end
+
+---@param rider IsoPlayer
+---@return boolean
+---@nodiscard
+function Mounts.isInterpolated(rider)
+    return interpolatedRiders[rider] == true
+end
 
 
 ---Triggered when a player mounts a horse.
@@ -44,11 +66,19 @@ Mounts.onDismount = Event.new--[[@<IsoPlayer, IsoAnimal?>]]()
 
 
 ---@readonly
-local LOCK_REFRESH_TICKS = 6000
+local LOCK_REFRESH_TICKS = 40
+
+---@readonly
+local WANDER_SUPPRESS_TIMER = 10000
 
 ---@param animal IsoAnimal
 local function refreshMountedAnimalBlock(animal)
-    animal:getBehavior():setBlockMovement(true)
+    local behavior = animal:getBehavior()
+    -- The engine expires the block once blockedFor reaches 8000 and only the false
+    -- branch resets that counter, so re-blocking alone lets vanilla wander resume,
+    -- path the horse and flip it into the walk action state mid-ride.
+    behavior:setBlockMovement(false)
+    behavior:setBlockMovement(true)
     mountedAnimalLockTicks[commands.getAnimalId(animal)] = 0
 end
 
@@ -86,9 +116,9 @@ local function syncMountedPlayerToAnimal(player, animal)
 end
 
 ---@param animal IsoAnimal
-local function setMountedAnimalLock(animal)
+---@param animalId integer
+local function setMountedAnimalLock(animal, animalId)
     -- Per-tick: only refresh the block-movement timeout
-    local animalId = commands.getAnimalId(animal)
     local ticks = mountedAnimalLockTicks[animalId]
     if not ticks then
         ticks = 0
@@ -116,6 +146,10 @@ local function suppressMountedAnimalAI(animal)
 
     animal:setVariable("bMoving", false)
     animal:setVariable("bPathfind", false)
+    -- vanilla wander fires on getStateEventDelayTimer() <= 0 and the timer is decremented
+    -- by an FPS-scaled multiplier, so clearing state per frame loses at low framerates.
+    -- Holding the timer far positive is a time budget: one write covers a whole frame.
+    animal:setStateEventDelayTimer(WANDER_SUPPRESS_TIMER)
 end
 
 ---@param animal IsoAnimal
@@ -205,6 +239,7 @@ local function removeMountID(player)
     playerMountMap[player] = nil
     mountPlayerMap[id] = nil
     mountedAnimalLockTicks[id] = nil
+    interpolatedRiders[player] = nil
 end
 
 ---@param player IsoPlayer
@@ -361,10 +396,25 @@ function Mounts.sendMounts(recipient)
     end
 end
 
+---Vanilla re-enters AnimalWalkState from inside the engine's own update, so clearing
+---the state once per frame loses the race. This is the cheap half of updateMounts,
+---run on the extra per-frame hooks; the full sweep still runs only once.
+local function pinMountedAnimals()
+    for player, mount in pairs(playerMountMap) do
+        local animal = commands.getAnimal(mount)
+        if animal then
+            suppressMountedAnimalAI(animal)
+        end
+    end
+end
+
 ---Keep mounted animals out of vanilla animal locomotion while riding owns transforms.
 local function updateMounts()
     for player, mount in pairs(playerMountMap) do
-        setMountedPlayerLock(player)
+        local interpolated = interpolatedRiders[player] == true
+        if not interpolated then
+            setMountedPlayerLock(player)
+        end
 
         local animal = commands.getAnimal(mount)
         if not animal then
@@ -372,13 +422,13 @@ local function updateMounts()
                 log("WEIRD: tried to update unknown animal id=%d player=%s", mount, player:getUsername())
             end
         else
-            setMountedAnimalLock(animal)
-            -- the vanilla state machine only ticks in SP and on the MP server.
-            -- Suppress alerted state there to stop Idle/Walk flipping near zombies
-            if not IS_CLIENT then
-                suppressMountedAnimalAI(animal)
+            setMountedAnimalLock(animal, mount)
+            -- Clients too: the block stops vanilla starting a new wander, this clears
+            -- bMoving if something already set it. Both are needed.
+            suppressMountedAnimalAI(animal)
+            if not interpolated then
+                syncMountedPlayerToAnimal(player, animal)
             end
-            syncMountedPlayerToAnimal(player, animal)
         end
     end
 end
@@ -393,16 +443,36 @@ local function dismountOnDeath(character)
     Mounts.removeMount(character)
 end
 
+local CLEANUP_INTERVAL_MS = 1000
+local lastCleanupStamp = 0
+
+---@type IsoPlayer[]
+local mountedScratch = {}
+local mountedScratchCount = 0
+
+---@type table<string, true>
+local onlineUsernameScratch = {}
+
 -- No reliable Lua event to use for detecting player disconnects
 -- So if player disconnects while riding we need to clean up mounts at regular intervals
 local function cleanupDisconnectedRiders()
-    local mounted
-    for player, _ in pairs(playerMountMap) do
-        mounted = mounted or {}
-        mounted[#mounted + 1] = player
+    local now = getTimestampMs()
+    if now - lastCleanupStamp < CLEANUP_INTERVAL_MS then
+        return
+    end
+    lastCleanupStamp = now
+
+    local previousCount = mountedScratchCount
+    mountedScratchCount = 0
+    for player in pairs(playerMountMap) do
+        mountedScratchCount = mountedScratchCount + 1
+        mountedScratch[mountedScratchCount] = player
+    end
+    for i = mountedScratchCount + 1, previousCount do
+        mountedScratch[i] = nil
     end
 
-    if not mounted then
+    if mountedScratchCount == 0 then
         return
     end
 
@@ -411,24 +481,31 @@ local function cleanupDisconnectedRiders()
         return
     end
 
-    local online = {}
+    for username in pairs(onlineUsernameScratch) do
+        onlineUsernameScratch[username] = nil
+    end
+
     for i = 0, onlinePlayers:size() - 1 do
         local p = onlinePlayers:get(i)
         if p then
-            online[p:getUsername()] = true
+            onlineUsernameScratch[p:getUsername()] = true
         end
     end
 
-    for _, player in ipairs(mounted) do
-        if not online[player:getUsername()] then
+    for i = 1, mountedScratchCount do
+        local player = mountedScratch[i]
+        if not onlineUsernameScratch[player:getUsername()] then
             Mounts.removeMount(player)
         end
     end
 end
 
 if IS_CLIENT then
+    -- The full sweep stays on one hook; only the cheap state pin needs the extra
+    -- coverage to beat vanilla back into idle within the same frame.
     Events.OnTickEvenPaused.Add(updateMounts)
-    Events.OnTick.Add(updateMounts)
+    Events.OnTick.Add(pinMountedAnimals)
+    Events.OnPlayerUpdate.Add(pinMountedAnimals)
 elseif IS_SERVER then
     Events.OnTickEvenPaused.Add(updateMounts)
     Events.OnTickEvenPaused.Add(cleanupDisconnectedRiders)

--- a/Contents/mods/HorseMod/42/media/lua/shared/HorseMod/networking/commands.lua
+++ b/Contents/mods/HorseMod/42/media/lua/shared/HorseMod/networking/commands.lua
@@ -1,6 +1,7 @@
 ---@namespace HorseMod
 
 local spobjects = require("HorseMod/networking/spobjects")
+local netmetrics = require("HorseMod/networking/netmetrics")
 
 local IS_CLIENT = isClient()
 local IS_SERVER = isServer()
@@ -21,6 +22,10 @@ local ClientCommand = {}
 ---@param args T Arguments to send to the server.
 function ClientCommand:send(sender, args)
     assert(not IS_SERVER, "tried to send client command from server, name=" .. self.name)
+    if netmetrics.enabled then
+        netmetrics.recordSend(self.name, self.id, sender ~= nil, args)
+    end
+
     if sender then
         sendClientCommand(sender, MODULE, tostring(self.id), args)
     else
@@ -37,6 +42,10 @@ local ServerCommand = {}
 ---@param args T Arguments to send to the client(s).
 function ServerCommand:send(recipient, args)
     assert(not IS_CLIENT, "tried to send server command from client, name=" .. self.name)
+    if netmetrics.enabled then
+        netmetrics.recordSend(self.name, self.id, recipient ~= nil, args)
+    end
+
     if IS_SERVER then
         if recipient then
             sendServerCommand(recipient, MODULE, tostring(self.id), args)

--- a/Contents/mods/HorseMod/42/media/lua/shared/HorseMod/networking/mountcommands.lua
+++ b/Contents/mods/HorseMod/42/media/lua/shared/HorseMod/networking/mountcommands.lua
@@ -49,9 +49,13 @@ local mountcommands = {}
 ---@field hasReins boolean
 
 ---@class RequestMountsArguments
+---Chunk grid width of the requesting client, used to approximate its relevance area.
+---@field w integer
 
+---Descriptive riding snapshot used inside the mod. It is converted to and from
+---the compact wire form by :lua:module:`HorseMod.networking.ridingcodec`.
 ---@class RidingStateArguments
----@field character integer|string
+---@field character integer
 ---@field animal integer
 ---@field seq integer
 ---@field x number
@@ -64,6 +68,7 @@ local mountcommands = {}
 ---@field jump boolean
 ---@field turn integer
 ---@field hasReins boolean
+---@field idleToRun boolean
 
 ---@class KickRequestArguments
 ---@field zombieId integer
@@ -77,7 +82,7 @@ local mountcommands = {}
 mountcommands.Mount = commands.registerServerCommand--[[@<MountArguments>]]("Mount")
 mountcommands.Dismount = commands.registerServerCommand--[[@<DismountArguments>]]("Dismount")
 mountcommands.SendMounts = commands.registerServerCommand--[[@<SendMountsArguments>]]("SendMounts")
-mountcommands.RidingState = commands.registerServerCommand--[[@<RidingStateArguments>]]("RidingState")
+mountcommands.RidingState = commands.registerServerCommand--[[@<RidingStateWire>]]("RidingState")
 mountcommands.UrgentDismount = commands.registerServerCommand--[[@<UrgentDismountArguments>]]("UrgentDismount")
 mountcommands.KickPerformed = commands.registerServerCommand--[[@<KickPerformedArguments>]]("KickPerformed")
 

--- a/Contents/mods/HorseMod/42/media/lua/shared/HorseMod/networking/netmetrics.lua
+++ b/Contents/mods/HorseMod/42/media/lua/shared/HorseMod/networking/netmetrics.lua
@@ -1,0 +1,242 @@
+---@namespace HorseMod
+
+---@class NetCommandMetric
+---@field name string
+---@field id integer
+---@field sends integer
+---@field targeted integer
+---@field broadcasts integer
+---@field argBytes integer
+---@field envelopeBytes integer
+
+---@class NetMetricsSnapshot
+---@field elapsed number
+---@field commands NetCommandMetric[]
+---@field counters table<string, integer>
+---@field totalSends integer
+---@field totalBytes integer
+---@field sendsPerSecond number
+---@field bytesPerSecond number
+
+local PACKET_HEADER_BYTES = 3
+local BOOLEAN_FLAG_BYTES = 1
+local STRING_OVERHEAD_BYTES = 3
+local NUMBER_BYTES = 9
+local BOOLEAN_BYTES = 2
+local TABLE_COUNT_BYTES = 4
+local MODULE_BYTES = STRING_OVERHEAD_BYTES + 8
+
+local netmetrics = {}
+
+---Set to true to start estimating traffic. Every hot-path call site must test
+---this field before doing any work; nothing here is free once it is on.
+netmetrics.enabled = false
+
+---@type table<integer, NetCommandMetric>
+local commandMetrics = {}
+
+---@type table<string, integer>
+local counters = {}
+
+local windowStart = 0
+local totalSends = 0
+local totalBytes = 0
+
+---@param value any
+---@return integer
+---@nodiscard
+local function estimateValueBytes(value)
+    local valueType = type(value)
+    if valueType == "number" then
+        return NUMBER_BYTES
+    elseif valueType == "boolean" then
+        return BOOLEAN_BYTES
+    elseif valueType == "string" then
+        return STRING_OVERHEAD_BYTES + #value
+    elseif valueType == "table" then
+        local bytes = 1 + TABLE_COUNT_BYTES
+        for key, nested in pairs(value) do
+            bytes = bytes + estimateValueBytes(key) + estimateValueBytes(nested)
+        end
+        return bytes
+    end
+
+    return 0
+end
+
+---Estimated payload bytes for a command argument table.
+---This mirrors TableNetworkUtils.save and is not a measured socket byte count.
+---@param args table?
+---@return integer
+---@nodiscard
+function netmetrics.estimateArgBytes(args)
+    if not args then
+        return 0
+    end
+
+    local bytes = TABLE_COUNT_BYTES
+    for key, value in pairs(args) do
+        local valueBytes = estimateValueBytes(value)
+        if valueBytes > 0 then
+            bytes = bytes + estimateValueBytes(key) + valueBytes
+        end
+    end
+
+    return bytes
+end
+
+---@param commandId integer
+---@return integer
+---@nodiscard
+local function estimateEnvelopeBytes(commandId)
+    local idLength = 1
+    if commandId >= 100 then
+        idLength = 3
+    elseif commandId >= 10 then
+        idLength = 2
+    end
+
+    return PACKET_HEADER_BYTES + MODULE_BYTES + STRING_OVERHEAD_BYTES + idLength + BOOLEAN_FLAG_BYTES
+end
+
+---@param name string
+---@param id integer
+---@return NetCommandMetric
+---@nodiscard
+local function getCommandMetric(name, id)
+    local metric = commandMetrics[id]
+    if metric then
+        return metric
+    end
+
+    metric = {
+        name = name,
+        id = id,
+        sends = 0,
+        targeted = 0,
+        broadcasts = 0,
+        argBytes = 0,
+        envelopeBytes = 0,
+    }
+    commandMetrics[id] = metric
+
+    return metric
+end
+
+---@param name string
+---@param id integer
+---@param isTargeted boolean
+---@param args table?
+function netmetrics.recordSend(name, id, isTargeted, args)
+    local metric = getCommandMetric(name, id)
+    local argBytes = netmetrics.estimateArgBytes(args)
+    local envelopeBytes = estimateEnvelopeBytes(id)
+
+    metric.sends = metric.sends + 1
+    if isTargeted then
+        metric.targeted = metric.targeted + 1
+    else
+        metric.broadcasts = metric.broadcasts + 1
+    end
+    metric.argBytes = metric.argBytes + argBytes
+    metric.envelopeBytes = metric.envelopeBytes + envelopeBytes
+
+    totalSends = totalSends + 1
+    totalBytes = totalBytes + argBytes + envelopeBytes
+end
+
+---@param key string
+---@param amount integer?
+function netmetrics.count(key, amount)
+    local delta = amount
+    if not delta then
+        delta = 1
+    end
+
+    local current = counters[key]
+    if not current then
+        current = 0
+    end
+    counters[key] = current + delta
+end
+
+function netmetrics.reset()
+    commandMetrics = {}
+    counters = {}
+    totalSends = 0
+    totalBytes = 0
+    windowStart = getTimestampMs()
+end
+
+---@param enable boolean
+function netmetrics.setEnabled(enable)
+    netmetrics.enabled = enable == true
+    netmetrics.reset()
+end
+
+---@return NetMetricsSnapshot
+---@nodiscard
+function netmetrics.snapshot()
+    local elapsed = (getTimestampMs() - windowStart) / 1000
+    if elapsed <= 0 then
+        elapsed = 0.001
+    end
+
+    ---@type NetCommandMetric[]
+    local commandList = {}
+    for _, metric in pairs(commandMetrics) do
+        commandList[#commandList + 1] = metric
+    end
+
+    ---@type table<string, integer>
+    local counterCopy = {}
+    for key, value in pairs(counters) do
+        counterCopy[key] = value
+    end
+
+    return {
+        elapsed = elapsed,
+        commands = commandList,
+        counters = counterCopy,
+        totalSends = totalSends,
+        totalBytes = totalBytes,
+        sendsPerSecond = totalSends / elapsed,
+        bytesPerSecond = totalBytes / elapsed,
+    }
+end
+
+function netmetrics.dump()
+    local snapshot = netmetrics.snapshot()
+    DebugLog.log(string.format(
+        "[HorseMod] [NetMetrics] window=%.1fs sends=%d estimatedPayloadBytes=%d sends/s=%.1f estimatedBytes/s=%.0f",
+        snapshot.elapsed,
+        snapshot.totalSends,
+        snapshot.totalBytes,
+        snapshot.sendsPerSecond,
+        snapshot.bytesPerSecond
+    ))
+
+    for i = 1, #snapshot.commands do
+        local metric = snapshot.commands[i]
+        DebugLog.log(string.format(
+            "[HorseMod] [NetMetrics] %s id=%d sends=%d targeted=%d broadcasts=%d args=%dB envelope=%dB",
+            metric.name,
+            metric.id,
+            metric.sends,
+            metric.targeted,
+            metric.broadcasts,
+            metric.argBytes,
+            metric.envelopeBytes
+        ))
+    end
+
+    for key, value in pairs(snapshot.counters) do
+        DebugLog.log(string.format("[HorseMod] [NetMetrics] counter %s=%d", key, value))
+    end
+end
+
+netmetrics.reset()
+
+HorseModNetMetrics = netmetrics
+
+return netmetrics

--- a/Contents/mods/HorseMod/42/media/lua/shared/HorseMod/networking/relevance.lua
+++ b/Contents/mods/HorseMod/42/media/lua/shared/HorseMod/networking/relevance.lua
@@ -1,0 +1,109 @@
+---@namespace HorseMod
+
+---Approximation of the engine relevance test used by ``UdpConnection.isRelevantTo``.
+---The real test is not reachable from Lua, so riders route their own snapshots.
+local relevance = {}
+
+---@readonly
+relevance.MIN_CHUNK_GRID_WIDTH = 12
+
+---@readonly
+relevance.MAX_CHUNK_GRID_WIDTH = 20
+
+---@readonly
+relevance.MIN_RANGE_TILES = 64
+
+---@readonly
+relevance.MAX_RANGE_TILES = 96
+
+---Mirrors ``GameServer.receivePlayerConnect``: the connection range is
+---``clamp(chunkGridWidth, 12, 20) / 2 + 2`` chunks, and a chunk is eight tiles.
+---@param chunkGridWidth number
+---@return integer rangeTiles
+---@nodiscard
+function relevance.chunkGridWidthToRangeTiles(chunkGridWidth)
+    local width = math.floor(chunkGridWidth)
+    if width < relevance.MIN_CHUNK_GRID_WIDTH then
+        width = relevance.MIN_CHUNK_GRID_WIDTH
+    elseif width > relevance.MAX_CHUNK_GRID_WIDTH then
+        width = relevance.MAX_CHUNK_GRID_WIDTH
+    end
+
+    return (math.floor(width / 2) + 2) * 8
+end
+
+---Converts a reported chunk grid width into a range the server is willing to trust.
+---Anything missing or malformed falls back to the widest range so a client can
+---never shrink its own relevance area to hide riders.
+---@param reportedWidth any
+---@return integer rangeTiles
+---@nodiscard
+function relevance.sanitizeReportedWidth(reportedWidth)
+    if type(reportedWidth) ~= "number" then
+        return relevance.MAX_RANGE_TILES
+    end
+
+    if reportedWidth ~= reportedWidth or reportedWidth <= 0 then
+        return relevance.MAX_RANGE_TILES
+    end
+
+    local rangeTiles = relevance.chunkGridWidthToRangeTiles(reportedWidth)
+    if rangeTiles < relevance.MIN_RANGE_TILES then
+        return relevance.MIN_RANGE_TILES
+    elseif rangeTiles > relevance.MAX_RANGE_TILES then
+        return relevance.MAX_RANGE_TILES
+    end
+
+    return rangeTiles
+end
+
+---Mirrors ``IsoChunkMap.CalcChunkWidth`` so a client can report the same grid
+---width the engine sent in its connect packet. Debug chunk-map overrides are not
+---visible here, and they only ever shrink the grid, so over-reporting is safe.
+---@return integer chunkGridWidth
+---@nodiscard
+function relevance.getLocalChunkGridWidth()
+    local core = getCore()
+    local del = math.max(core:getScreenWidth() / 1920, core:getScreenHeight() / 1080)
+    if del > 1 then
+        del = 1
+    end
+
+    local width = math.floor(13 * del * 1.5)
+    if math.floor(width / 2) * 2 == width then
+        width = width + 1
+    end
+
+    if width > 19 then
+        width = 19
+    end
+
+    return width
+end
+
+---Axis-aligned test matching the shape of the engine relevance rectangle.
+---@param x number
+---@param y number
+---@param observerX number
+---@param observerY number
+---@param rangeTiles number
+---@return boolean
+---@nodiscard
+function relevance.isInRange(x, y, observerX, observerY, rangeTiles)
+    local dx = observerX - x
+    if dx < 0 then
+        dx = -dx
+    end
+    if dx > rangeTiles then
+        return false
+    end
+
+    local dy = observerY - y
+    if dy < 0 then
+        dy = -dy
+    end
+
+    return dy <= rangeTiles
+end
+
+return relevance

--- a/Contents/mods/HorseMod/42/media/lua/shared/HorseMod/networking/ridingcodec.lua
+++ b/Contents/mods/HorseMod/42/media/lua/shared/HorseMod/networking/ridingcodec.lua
@@ -1,0 +1,215 @@
+---@namespace HorseMod
+
+local IS_CLIENT = isClient()
+local IS_SERVER = isServer()
+local IS_SINGLEPLAYER = not (IS_CLIENT or IS_SERVER)
+
+---Compact wire form of a riding snapshot. Keys are single characters because
+---``TableNetworkUtils`` writes every key as a full UTF string.
+---@class RidingStateWire
+---@field r integer Rider id
+---@field a integer Animal id
+---@field s integer Server state sequence
+---@field x number
+---@field y number
+---@field z number
+---@field v number Speed
+---@field f integer Packed direction and gait flags
+
+local FLAG_GALLOP = 8
+local FLAG_TROT = 16
+local FLAG_JUMP = 32
+local FLAG_TURN = 64
+local FLAG_REINS = 256
+local FLAG_IDLE_TO_RUN = 512
+local FLAG_LIMIT = 1024
+
+local MAX_SPEED = 24
+local MAX_COORDINATE = 100000
+local MAX_VERTICAL = 32
+
+local ridingcodec = {}
+
+---@readonly
+ridingcodec.FIELD_COUNT = 8
+
+---@param value any
+---@return boolean
+---@nodiscard
+local function isFiniteNumber(value)
+    if type(value) ~= "number" then
+        return false
+    end
+
+    return value == value and value > -math.huge and value < math.huge
+end
+
+---@param player IsoPlayer
+---@return integer
+---@nodiscard
+function ridingcodec.encodePlayerId(player)
+    if IS_SINGLEPLAYER then
+        return player:getIndex()
+    end
+
+    return player:getOnlineID()
+end
+
+---@param id integer
+---@return IsoPlayer?
+---@nodiscard
+function ridingcodec.decodePlayerId(id)
+    if IS_SINGLEPLAYER then
+        return getSpecificPlayer(id)
+    end
+
+    local player = getPlayerByOnlineID(id)
+    if player then
+        return player
+    end
+
+    -- A listen-server host holds online id 0 and can be absent from the client
+    -- id map, so fall back to a scan before giving up on the snapshot.
+    local players = getOnlinePlayers()
+    if not players then
+        return nil
+    end
+
+    for i = 0, players:size() - 1 do
+        local candidate = players:get(i)
+        if candidate and candidate:getOnlineID() == id then
+            return candidate
+        end
+    end
+
+    return nil
+end
+
+---@param dir integer
+---@param gallop boolean
+---@param trot boolean
+---@param jump boolean
+---@param turn integer
+---@param hasReins boolean
+---@param idleToRun boolean
+---@return integer
+---@nodiscard
+function ridingcodec.packFlags(dir, gallop, trot, jump, turn, hasReins, idleToRun)
+    local flags = dir % 8
+
+    if gallop then
+        flags = flags + FLAG_GALLOP
+    end
+    if trot then
+        flags = flags + FLAG_TROT
+    end
+    if jump then
+        flags = flags + FLAG_JUMP
+    end
+    if hasReins then
+        flags = flags + FLAG_REINS
+    end
+    if idleToRun then
+        flags = flags + FLAG_IDLE_TO_RUN
+    end
+
+    local turnCode = 1
+    if turn < 0 then
+        turnCode = 0
+    elseif turn > 0 then
+        turnCode = 2
+    end
+
+    return flags + turnCode * FLAG_TURN
+end
+
+---@param args RidingStateArguments
+---@return RidingStateWire
+---@nodiscard
+function ridingcodec.encode(args)
+    return {
+        r = args.character,
+        a = args.animal,
+        s = args.seq,
+        x = args.x,
+        y = args.y,
+        z = args.z,
+        v = args.speed,
+        f = ridingcodec.packFlags(
+            args.dir,
+            args.gallop,
+            args.trot,
+            args.jump,
+            args.turn,
+            args.hasReins,
+            args.idleToRun
+        ),
+    }
+end
+
+---Rebuilds the descriptive snapshot from the wire form.
+---Returns nil when any field is missing or out of range; a rejected packet must
+---never be partially applied.
+---@param wire RidingStateWire
+---@return RidingStateArguments?
+---@nodiscard
+function ridingcodec.decode(wire)
+    if type(wire) ~= "table" then
+        return nil
+    end
+
+    if not isFiniteNumber(wire.r)
+            or not isFiniteNumber(wire.a)
+            or not isFiniteNumber(wire.s)
+            or not isFiniteNumber(wire.x)
+            or not isFiniteNumber(wire.y)
+            or not isFiniteNumber(wire.z)
+            or not isFiniteNumber(wire.v)
+            or not isFiniteNumber(wire.f) then
+        return nil
+    end
+
+    if wire.x < -MAX_COORDINATE or wire.x > MAX_COORDINATE
+            or wire.y < -MAX_COORDINATE or wire.y > MAX_COORDINATE
+            or wire.z < -MAX_VERTICAL or wire.z > MAX_VERTICAL then
+        return nil
+    end
+
+    if wire.v < 0 or wire.v > MAX_SPEED then
+        return nil
+    end
+
+    local flags = math.floor(wire.f)
+    if flags ~= wire.f or flags < 0 or flags >= FLAG_LIMIT then
+        return nil
+    end
+
+    local turnCode = math.floor(flags / FLAG_TURN) % 4
+    if turnCode > 2 then
+        return nil
+    end
+
+    local sequence = math.floor(wire.s)
+    if sequence ~= wire.s or sequence < 0 then
+        return nil
+    end
+
+    return {
+        character = math.floor(wire.r),
+        animal = math.floor(wire.a),
+        seq = sequence,
+        x = wire.x,
+        y = wire.y,
+        z = wire.z,
+        dir = flags % 8,
+        speed = wire.v,
+        gallop = math.floor(flags / FLAG_GALLOP) % 2 == 1,
+        trot = math.floor(flags / FLAG_TROT) % 2 == 1,
+        jump = math.floor(flags / FLAG_JUMP) % 2 == 1,
+        turn = turnCode - 1,
+        hasReins = math.floor(flags / FLAG_REINS) % 2 == 1,
+        idleToRun = math.floor(flags / FLAG_IDLE_TO_RUN) % 2 == 1,
+    }
+end
+
+return ridingcodec

--- a/Contents/mods/HorseMod/42/media/lua/shared/HorseMod/riding/RidingMovement.lua
+++ b/Contents/mods/HorseMod/42/media/lua/shared/HorseMod/riding/RidingMovement.lua
@@ -1271,6 +1271,10 @@ function RidingMovement:followVertical(mount, deltaTime)
     -- Update mount's current square
     mount:setCurrent(best)
     mount:setMovingSquareNow()
+    -- setMovingSquareNow moves movingObjects membership, but getMovingObjectIndex()
+    -- reads the raw square field, so leave the two agreeing or the animal reads as
+    -- absent from its own square.
+    mount:setSquare(best)
 
     -- Refresh ramp grace period if on slope
     if squareIsRamp(best) then
@@ -1391,7 +1395,9 @@ function RidingMovement:update(input, deltaTime)
 
     self:updateSpeed(input, deltaTime)
 
-    local needsEngineMoving = isServer()
+    -- bMoving is a callback bound to isMoving(), and suppressMountedAnimalAI clears it
+    -- every tick; setting it true here made the two fight and flipped the action state
+    -- between buck/idle and buck/walk, restarting the mounted clip.
     local gallopActive
     if self.speed > 0 and not rider:getVariableBoolean(AnimationVariable.DISMOUNT_STARTED) then
         local moveAngle = MountedDirection.getMovementAngle(mount, self.direction)
@@ -1400,19 +1406,11 @@ function RidingMovement:update(input, deltaTime)
 
         gallopActive = input.run == true
         self.pair:setAnimationVariable(AnimationVariable.GALLOP, gallopActive)
-        -- mount:setMoving(true) only needed on the server
-        -- so animal sync sends the moving state to other clients
         setMountedMovementVariables(self.pair, true, gallopActive)
-        if needsEngineMoving then
-            mount:setMoving(true)
-        end
     else
         gallopActive = false
         self.pair:setAnimationVariable(AnimationVariable.GALLOP, false)
         setMountedMovementVariables(self.pair, false, false)
-        if needsEngineMoving then
-            mount:setMoving(false)
-        end
     end
 
     if gallopActive and not self.wasGalloping then


### PR DESCRIPTION
Add a shared riding wire codec, chunk-relevance filtering and an opt-in netmetrics counter module, and route the riding/mount commands through them. Clients buffer out-of-order riding state in PendingRidingState and flush it once the mount resolves, so remote riders no longer snap or desync while the horse is still streaming in.

Also retimes the mounted walk/trot and turn AnimSets.